### PR TITLE
feat: 서랍장 레이아웃 컴포넌트 구현

### DIFF
--- a/src/drawer/components/Layout/Layout.style.ts
+++ b/src/drawer/components/Layout/Layout.style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const StyledLayout = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+`;

--- a/src/drawer/components/Layout/Layout.style.ts
+++ b/src/drawer/components/Layout/Layout.style.ts
@@ -2,8 +2,10 @@ import styled from 'styled-components';
 
 export const StyledLayout = styled.div`
   width: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   position: relative;
+  padding-bottom: 80px;
 `;

--- a/src/drawer/components/Layout/Layout.tsx
+++ b/src/drawer/components/Layout/Layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+
+import { StyledLayout } from './Layout.style';
+
+export const Layout = () => {
+  return (
+    <StyledLayout>
+      {/* 헤더 */}
+      <Outlet />
+      {/* 푸터 */}
+    </StyledLayout>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+#root {
+  width: 100%;
+}
+
 a {
   font-weight: 500;
   color: #646cff;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
 
 import { Drawer } from './drawer/Drawer';
+import { Layout as DrawerLayout } from './drawer/components/Layout/Layout';
 import { Home } from './home/Home';
 import { Search } from './search/Search';
 
@@ -8,7 +9,9 @@ export const Router = () => {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
-      <Route path="/drawer" element={<Drawer />} />
+      <Route path="/drawer" element={<DrawerLayout />}>
+        <Route path="" element={<Drawer />} />
+      </Route>
       <Route path="/search" element={<Search />} />
     </Routes>
   );


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
- #7 

### 기존 코드에 영향을 미치지 않는 변경사항
- `src/drawer/components/Layout`에 레이아웃 컴포넌트를 구현했습니다

### 기존 코드에 영향을 미치는 변경사항
- `router.tsx` : `Drawer`를 `DrawerLayout`으로 감쌌습니다
- `index.css` : 화면 전체 너비를 차지하도록 설정하기 위해 `#root { width: 100% }` 추가했습니다

**⚠ 화면 속 헤더와 푸터, 컨텐츠 영역의 배경색은 이해를 돕기 위해 임의로 넣은 것이며 실제 코드에 작성되어있지 않습니다**

![example](https://github.com/yourssu/Soomsil-Web/assets/87255462/8cbf2a30-a890-41f6-afaf-0d6e5c44d70e)


## 2️⃣ 알아두시면 좋아요!
- 레이아웃 컴포넌트의 가로가 화면 전체를 차지하게 하려고 `index.css`를 약간 만졌습니다..!

  `Layout` width를 100vw로 설정해도 되긴 하는디,, 그러면 스크롤 너비를 고려해야 해서 이렇게 해봤읍니다,,🤪

## 3️⃣ 추후 작업
- 헤더와 푸터 구현 이후 추가 확인 필요

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
