### PR TITLE
feat: add styled-components.d.ts

### DIFF
--- a/src/types/styled-components.d.ts
+++ b/src/types/styled-components.d.ts
@@ -1,0 +1,6 @@
+import 'styled-components';
+import { YDSTheme } from '@yourssu/design-system-react';
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends YDSTheme {}
+}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

theme 사용 시 YDSTheme을 가져오기 위해 styled-components.d.ts 추가 후 YDSTheme을 extends 해주었습니당

- 보리와의 대화 히스토리: https://github.com/yourssu/YDS-React/pull/31

## 2️⃣ 알아두시면 좋아요!

마안약 YDS 내에 정의되지 않은 컬러를 theme으로 불러오고 싶을 경우(다크모드 지원 등) DefaultTheme 타입에 추가적인 속성을 정의해주시면 됩니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
