### PR TITLE
feat: 서랍장 Button, Footer 구현 (#5)

### DIFF
--- a/src/drawer/components/Button/Button.style.ts
+++ b/src/drawer/components/Button/Button.style.ts
@@ -7,11 +7,11 @@ interface StyledButtonProps {
 export const StyledButton = styled.button<StyledButtonProps>`
   padding: 8px 32px;
   border-radius: 9999px;
-  background-color: ${({ $isFilled }: StyledButtonProps) =>
+  background-color: ${({ $isFilled }) =>
     $isFilled ? ({ theme }) => theme.color.buttonPoint : 'transparent'};
-  color: ${({ $isFilled }: StyledButtonProps) =>
+  color: ${({ $isFilled }) =>
     $isFilled ? ({ theme }) => theme.color.bgNormal : ({ theme }) => theme.color.buttonPoint};
-  border: ${({ $isFilled }: StyledButtonProps) =>
+  border: ${({ $isFilled }) =>
     $isFilled ? 'none' : ({ theme }) => `1px solid ${theme.color.buttonPoint}`};
   font-style: ${({ theme }) => theme.typo.caption0};
   &:focus {

--- a/src/drawer/components/Button/Button.style.ts
+++ b/src/drawer/components/Button/Button.style.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+interface StyledButtonProps {
+  $isFilled?: boolean;
+}
+
+export const StyledButton = styled.button<StyledButtonProps>`
+  padding: 8px 32px;
+  border-radius: 9999px;
+  background-color: ${({ $isFilled }: StyledButtonProps) =>
+    $isFilled ? ({ theme }) => theme.color.buttonPoint : 'transparent'};
+  color: ${({ $isFilled }: StyledButtonProps) =>
+    $isFilled ? ({ theme }) => theme.color.bgNormal : ({ theme }) => theme.color.buttonPoint};
+  border: ${({ $isFilled }: StyledButtonProps) =>
+    $isFilled ? 'none' : ({ theme }) => `1px solid ${theme.color.buttonPoint}`};
+  font-style: ${({ theme }) => theme.typo.caption0};
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/drawer/components/Button/Button.tsx
+++ b/src/drawer/components/Button/Button.tsx
@@ -1,0 +1,15 @@
+import { StyledButton } from './Button.style';
+
+interface ButtonProps {
+  text: string;
+  onClick: () => void;
+  isFilled?: boolean;
+}
+
+export const Button = ({ text, onClick, isFilled }: ButtonProps) => {
+  return (
+    <StyledButton onClick={onClick} $isFilled={isFilled}>
+      {text}
+    </StyledButton>
+  );
+};

--- a/src/drawer/components/Footer/Footer.style.ts
+++ b/src/drawer/components/Footer/Footer.style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const StyeldFooter = styled.footer`
+  display: flex;
+  position: absolute;
+  bottom: 0;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 80px;
+  background-color: ${({ theme }) => theme.color.bgPressed};
+`;
+
+export const StyledFooterLogo = styled.text``;
+
+export const StyledFooterText = styled.text`
+  margin-left: 30px;
+`;

--- a/src/drawer/components/Footer/Footer.tsx
+++ b/src/drawer/components/Footer/Footer.tsx
@@ -1,0 +1,10 @@
+import { StyeldFooter, StyledFooterLogo, StyledFooterText } from './Footer.style';
+
+export const Footer = () => {
+  return (
+    <StyeldFooter>
+      <StyledFooterLogo>SOOMSIL DRAWERS</StyledFooterLogo>
+      <StyledFooterText>Version n.n.n</StyledFooterText>
+    </StyeldFooter>
+  );
+};

--- a/src/drawer/components/Layout/Layout.tsx
+++ b/src/drawer/components/Layout/Layout.tsx
@@ -1,13 +1,14 @@
 import { Outlet } from 'react-router-dom';
 
 import { StyledLayout } from './Layout.style';
+import { Footer } from '../Footer/Footer';
 
 export const Layout = () => {
   return (
     <StyledLayout>
       {/* 헤더 */}
       <Outlet />
-      {/* 푸터 */}
+      <Footer />
     </StyledLayout>
   );
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- 서랍장에서 사용하는 listItem_category와 Footer를 구현했습니다.
- '더보기' 버튼과 YDS BoxButton을 제외한 버튼이 따로 없고, listItem_category 라는 이름이 뭔가 임시 네이밍(?)인 것 같은 느낌이 들어서 그냥 Button으로 네이밍했어용
- Footer는 폰트 픽스가 나중에 될 것 같다고 말씀하셔서 일단 레이아웃만 잡아뒀습니다.
- resolved #5 
### 테스트 화면
![image](https://github.com/yourssu/Soomsil-Web/assets/84809236/0faed1a9-22aa-4ca7-affa-e4ea7c0bcb39)

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)
아무나 #12 어프로브 플리즈....입니다............

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
