### PR TITLE
fix: Dropdown style.ts dom warning

### DIFF
--- a/src/components/Dropdown/Dropdown.style.ts
+++ b/src/components/Dropdown/Dropdown.style.ts
@@ -1,16 +1,21 @@
 import styled from 'styled-components';
 
-import { DropdownProps } from './Dropdown';
+interface StyledDropDownProps {
+  $padding: string;
+  $bottom: string;
+  $right?: string;
+  $left?: string;
+}
 
-export const StyledContainer = styled.div<DropdownProps>`
-  padding: ${(props) => props.padding};
-  left: ${(props) => props.left};
+export const StyledContainer = styled.div<StyledDropDownProps>`
+  padding: ${(props) => props.$padding};
+  left: ${(props) => props.$left};
   display: flex;
   flex-direction: column;
   position: absolute;
   z-index: 10;
-  bottom: ${(props) => props.bottom};
-  right: ${(props) => props.right};
+  bottom: ${(props) => props.$bottom};
+  right: ${(props) => props.$right};
   border-radius: 0.25rem;
   background: ${({ theme }) => theme.color.bgNormal};
   box-shadow: 0px 1px 3px 0px rgba(107, 114, 128, 0.4);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,17 +1,16 @@
-import { ReactNode } from 'react';
-
 import { StyledContainer } from './Dropdown.style';
 
 export interface DropdownProps {
+  children: React.ReactNode;
   padding: string;
   bottom: string;
   right?: string;
   left?: string;
-  children: ReactNode;
 }
+
 export const Dropdown = ({ children, padding, bottom, right, left }: DropdownProps) => {
   return (
-    <StyledContainer padding={padding} bottom={bottom} right={right} left={left}>
+    <StyledContainer $padding={padding} $bottom={bottom} $right={right} $left={left}>
       {children}
     </StyledContainer>
   );


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
@JjungminLee 확인 부탁드려요~!
- resolved #56 

### 버그 픽스
Dropdown에서 발생하고 있는 DOM Warning을 해결하였습니다.

![306709118-9145dd25-9b8e-4fe8-9c9f-6a021dbf8913](https://github.com/yourssu/Soomsil-Web/assets/84809236/e8c13750-b6d6-45e9-a8b1-c77eb662be17)

Dom Props 오염을 방지하기 위해 Styled Component로 전달되는 Props의 이름은 $로 시작해주세요~!
**Reference: https://styled-components.com/docs/faqs#transient-props-since-5.1 & https://styled-components.com/docs/api#transient-props**

추가로, 이러한 문제를 구별하기 쉽게 Styled Interface를 독립적으로 생성해주시면 좋을 것 같습니당

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
