### PR TITLE
refactor: 서랍장, Home화면 Card 컴포넌트 리팩토링

### DIFF
--- a/src/components/Card/Card.style.ts
+++ b/src/components/Card/Card.style.ts
@@ -38,11 +38,3 @@ export const StyledBookmarkContainer = styled.div`
   display: flex;
   align-items: center;
 `;
-
-export const StyledSettingButton = styled.button`
-  background-color: transparent;
-  border: none;
-  outline: none;
-  cursor: pointer;
-  width: 2.25rem;
-`;

--- a/src/components/Card/Card.style.ts
+++ b/src/components/Card/Card.style.ts
@@ -1,15 +1,15 @@
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface StyledContainerProps {
   $width: number;
 }
-export const StyledContainer = styled(Link)<StyledContainerProps>`
+export const StyledContainer = styled.div<StyledContainerProps>`
   width: ${(props) => `${props.$width}rem`};
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   text-decoration: none;
+  cursor: pointer;
 `;
 
 interface StyledThumbnailProps {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -4,6 +4,7 @@ import {
   IcStarLine,
   IcDotsVerticalLine,
 } from '@yourssu/design-system-react';
+import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 
 import BigThumbnail from '@/assets/bigThumbnail.png';
@@ -25,8 +26,14 @@ import {
 } from './Card.type';
 
 const CardContainer = ({ children, link, width = 25.5 }: CardContainerProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(link);
+  };
+
   return (
-    <StyledContainer to={link} $width={width}>
+    <StyledContainer onClick={handleClick} $width={width}>
       {children}
     </StyledContainer>
   );

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -4,6 +4,7 @@ import {
   IcStarLine,
   IcDotsVerticalLine,
 } from '@yourssu/design-system-react';
+import { useTheme } from 'styled-components';
 
 import BigThumbnail from '@/assets/bigThumbnail.png';
 import SmallThumbnail from '@/assets/smallThumbnail.png';
@@ -13,7 +14,6 @@ import {
   StyledContainer,
   StyledText,
   StyledTitle,
-  StyledSettingButton,
   StyledThumbnail,
   StyledBookmarkContainer,
 } from './Card.style';
@@ -53,6 +53,7 @@ const CardSmallThumbnail = ({ imgSrc }: CardThumbnailProps) => {
 };
 
 const CardContent = ({ title, body, bookmarkCount, isBookmarked }: CardContentProps) => {
+  const theme = useTheme();
   return (
     <FlexGrowItem>
       <StyledTitle>{title}</StyledTitle>
@@ -61,7 +62,7 @@ const CardContent = ({ title, body, bookmarkCount, isBookmarked }: CardContentPr
         <StyledText>{bookmarkCount}+</StyledText>
         <IconContext.Provider
           value={{
-            color: '#505458',
+            color: theme.color.buttonNormal,
             size: '15px',
           }}
         >
@@ -73,12 +74,13 @@ const CardContent = ({ title, body, bookmarkCount, isBookmarked }: CardContentPr
 };
 
 const CardSetting = ({ onClick }: CardSettingProps) => {
+  const theme = useTheme();
   return (
-    <StyledSettingButton onClick={onClick}>
-      <IconContext.Provider value={{ color: '#505458', size: '36px' }}>
-        <IcDotsVerticalLine />
-      </IconContext.Provider>
-    </StyledSettingButton>
+    <IconContext.Provider
+      value={{ color: theme.color.buttonNormal, size: '36px', height: '100%', onClick: onClick }}
+    >
+      <IcDotsVerticalLine />
+    </IconContext.Provider>
   );
 };
 

--- a/src/components/Card/Card.type.ts
+++ b/src/components/Card/Card.type.ts
@@ -16,5 +16,5 @@ export interface CardThumbnailProps {
 }
 
 export interface CardSettingProps {
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick: React.MouseEventHandler;
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,16 +2,16 @@ import { ReactNode } from 'react';
 
 import { StyledContainer } from './Dropdown.style';
 
-export interface DropdownProps {
+export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
   padding: string;
   bottom: string;
   right?: string;
   left?: string;
   children: ReactNode;
 }
-export const Dropdown = ({ children, padding, bottom, right, left }: DropdownProps) => {
+export const Dropdown = ({ children, padding, bottom, right, left, onClick }: DropdownProps) => {
   return (
-    <StyledContainer padding={padding} bottom={bottom} right={right} left={left}>
+    <StyledContainer padding={padding} bottom={bottom} right={right} left={left} onClick={onClick}>
       {children}
     </StyledContainer>
   );

--- a/src/drawer/components/DrawerCard/UserDrawerCard/UserDrawerCard.tsx
+++ b/src/drawer/components/DrawerCard/UserDrawerCard/UserDrawerCard.tsx
@@ -53,10 +53,19 @@ export const UserDrawerCard = ({
         isBookmarked={isBookmarked}
       />
       <StyledDropdownContainer ref={containerRef}>
-        <Card.Setting onClick={onClickSetting} />
+        <Card.Setting
+          onClick={(event) => {
+            event.stopPropagation();
+            onClickSetting();
+          }}
+        />
         {isCardSettingClicked && (
           <Dropdown padding="1rem" bottom="-4.5rem" right="0">
-            <StyledServiceTextContainer>
+            <StyledServiceTextContainer
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+            >
               <StyledServiceModify to="/drawer/register">서비스 수정</StyledServiceModify>
               <StyledServiceText>서비스 삭제</StyledServiceText>
             </StyledServiceTextContainer>

--- a/src/drawer/components/DrawerCard/UserDrawerCard/UserDrawerCard.tsx
+++ b/src/drawer/components/DrawerCard/UserDrawerCard/UserDrawerCard.tsx
@@ -60,12 +60,15 @@ export const UserDrawerCard = ({
           }}
         />
         {isCardSettingClicked && (
-          <Dropdown padding="1rem" bottom="-4.5rem" right="0">
-            <StyledServiceTextContainer
-              onClick={(event) => {
-                event.stopPropagation();
-              }}
-            >
+          <Dropdown
+            padding="1rem"
+            bottom="-4.5rem"
+            right="0"
+            onClick={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            <StyledServiceTextContainer>
               <StyledServiceModify to="/drawer/register">서비스 수정</StyledServiceModify>
               <StyledServiceText>서비스 삭제</StyledServiceText>
             </StyledServiceTextContainer>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #40

### 기존 코드에 영향을 미치지 않는 변경사항

- `CardContainer`를 Link에서 div로 수정했습니다

  유저가 업로드한 서비스를 보여주는 `UserDrawerCard`에 anchor 태그가 존재해서, [중첩 Link로 인한 경고가 발생](https://github.com/yourssu/Soomsil-Web/pull/34#discussion_r1493167739)하고 있었어요

- `Card` 컴포넌트 내에서 hex 값으로 주던 YDS Icon 색상을 semantic color로 수정했습니다 땡스투쭌....

- `UserDrawerCard` 설정 버튼 위치 조절을 위해 `IconContext`에 스타일 속성을 추가했습니다

  <details>
  <summary> 왜 스타일 컴포넌트에 css 추가하는 게 아니라 IconContext에 달았냐 </summary>
  
    <h3>제 맘입니다</h3>
  
    농담이고...... [이 PR](https://github.com/yourssu/Soomsil-Web/pull/34#discussion_r1493163850) 읽어보시면 **설정 버튼을 감싸던 스타일 컴포넌트에 css가 단 한 줄! 남게 된다는 걸 보실 수 있는데요**
    height 정도는 IconContext에서 지정 가능한 스타일이기 때문에 한 줄짜리 스타일 컴포넌트보단 이쪽이 깔끔할 거 같았어용
  </details>

### 기존 코드에 영향을 미치는 변경사항

- (@seocylucky) `UserDrawerCard` 내에서 상위 이벤트 전파를 막기 위해 코드를 추가했습니다 ~~오늘 체리를 너무 부르네요~~

- (@JjungminLee) `DropdownProps` 타입이 HTMLAttributes를 확장하도록 수정했습니다

> **⚠ 서랍장 랭킹 페이지에 있는 `BigDrawerCard`를 잠깐.. `UserDrawerCard`로 바꿔서 동작 확인만 했습니다** 
이미지 엑박 뜨는 거 제가 터미널 끄고 찍어서 그래여 뭐 문제 생긴거 절대 아님


![card_navigate](https://github.com/yourssu/Soomsil-Web/assets/87255462/1edba8bb-1e76-4d70-8fb7-71bffee22630)

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

- PR 리뷰 기반 수정 근데 내일 할래요 저 내일 수강신청이라 자야해요

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
