### PR TITLE
feat: 서랍장 서비스 등록 페이지 TextArea 컴포넌트 구현

### DIFF
--- a/src/drawer/components/Input/Input.style.ts
+++ b/src/drawer/components/Input/Input.style.ts
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 
 export const StyledContainer = styled.div`
-  width: 79.625rem;
-  display: flex;
-  justify-content: space-between;
   @media (max-width: 24.375rem) {
     width: 21.875rem;
   }
+
+  width: 79.625rem;
+  display: flex;
+  justify-content: space-between;
 `;
 
 export const StyledLabelContainer = styled.div`
@@ -15,12 +16,13 @@ export const StyledLabelContainer = styled.div`
 `;
 
 export const StyledInputContainer = styled.div`
-  width: 61.875rem;
-  display: flex;
-  flex-direction: column;
   @media (max-width: 24.375rem) {
     width: 16rem;
   }
+
+  width: 61.875rem;
+  display: flex;
+  flex-direction: column;
 `;
 
 interface StyledInputProps {
@@ -31,24 +33,21 @@ export const StyledInput = styled.input<StyledInputProps>`
   @media (max-width: 24.375rem) {
     ${({ theme }) => theme.typo.caption2};
   }
-  padding: 0.38rem;
-  border: 1px solid
-    ${({ $isWarned, theme }) => ($isWarned ? theme.color.buttonWarned : theme.color.buttonNormal)};
+
   ${({ theme }) => theme.typo.subtitle1};
-  background-color: transparent;
   color: ${({ $isWarned, theme }) =>
     $isWarned ? theme.color.buttonWarned : theme.color.textSecondary};
-  border-top: none;
-  border-left: none;
-  border-right: none;
-  &:focus {
-    outline: none;
-  }
+
+  padding: 0.38rem;
+  background-color: transparent;
+
+  border: none;
+  border-bottom: 1px solid
+    ${({ $isWarned, theme }) =>
+      $isWarned ? theme.color.buttonWarned : theme.color.buttonNormalPressed};
+
   &:disabled {
-    border: 1px solid ${({ theme }) => theme.color.buttonDisabled};
-    border-top: none;
-    border-left: none;
-    border-right: none;
+    border-bottom: 1px solid ${({ theme }) => theme.color.buttonDisabled};
   }
 `;
 
@@ -69,9 +68,11 @@ export const StyledLabelTitle = styled.label`
   @media (max-width: 24.375rem) {
     ${({ theme }) => theme.typo.caption0};
   }
+
   ${({ theme }) => theme.typo.subtitle3};
   color: ${({ theme }) => theme.color.textPrimary};
   word-break: keep-all;
+
   &:hover {
     cursor: pointer;
   }

--- a/src/drawer/components/Input/Input.style.ts
+++ b/src/drawer/components/Input/Input.style.ts
@@ -27,6 +27,7 @@ export const StyledInputContainer = styled.div`
 
 interface StyledInputProps {
   $isWarned?: boolean;
+  $hasText?: boolean;
 }
 
 export const StyledInput = styled.input<StyledInputProps>`
@@ -43,12 +44,15 @@ export const StyledInput = styled.input<StyledInputProps>`
 
   border: none;
   border-bottom: 1px solid
-    ${({ $isWarned, theme }) =>
-      $isWarned ? theme.color.buttonWarned : theme.color.buttonNormalPressed};
-
-  &:disabled {
-    border-bottom: 1px solid ${({ theme }) => theme.color.buttonDisabled};
-  }
+    ${({ $isWarned, $hasText, theme }) => {
+      if ($isWarned) {
+        return theme.color.buttonWarned;
+      } else if ($hasText) {
+        return theme.color.buttonNormalPressed;
+      } else {
+        return theme.color.buttonDisabled;
+      }
+    }};
 `;
 
 export const StyledInputLength = styled.span<StyledInputProps>`

--- a/src/drawer/components/Input/Input.tsx
+++ b/src/drawer/components/Input/Input.tsx
@@ -31,9 +31,9 @@ export const Input = ({ title, description, isWarned, ...props }: InputProps) =>
       </StyledLabelContainer>
       <StyledInputContainer>
         <StyledInput
+          id={title}
           value={inputValue}
           onChange={handleInputChange}
-          id={title}
           $isWarned={isWarned}
           {...props}
         />

--- a/src/drawer/components/Input/Input.tsx
+++ b/src/drawer/components/Input/Input.tsx
@@ -35,6 +35,7 @@ export const Input = ({ title, description, isWarned, ...props }: InputProps) =>
           value={inputValue}
           onChange={handleInputChange}
           $isWarned={isWarned}
+          $hasText={inputValue.length > 0}
           {...props}
         />
         {isWarned ? (

--- a/src/drawer/components/TextArea/TextArea.style.ts
+++ b/src/drawer/components/TextArea/TextArea.style.ts
@@ -52,6 +52,7 @@ export const StyledTextAreaContainer = styled.div`
 
 interface StyledTextAreaProps {
   $isWarned?: boolean;
+  $hasText?: boolean;
 }
 
 export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
@@ -68,13 +69,15 @@ export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
 
   border: none;
   border-bottom: 1px solid
-    ${({ $isWarned, theme }) => ($isWarned ? theme.color.buttonWarned : theme.color.buttonDisabled)};
-
-  &:focus {
-    border-bottom: 1px solid
-      ${({ $isWarned, theme }) =>
-        $isWarned ? theme.color.buttonWarned : theme.color.buttonNormalPressed};
-  }
+    ${({ $isWarned, $hasText, theme }) => {
+      if ($isWarned) {
+        return theme.color.buttonWarned;
+      } else if ($hasText) {
+        return theme.color.buttonNormalPressed;
+      } else {
+        return theme.color.buttonDisabled;
+      }
+    }};
 `;
 
 export const StyledTextAreaLength = styled.span<StyledTextAreaProps>`

--- a/src/drawer/components/TextArea/TextArea.style.ts
+++ b/src/drawer/components/TextArea/TextArea.style.ts
@@ -1,0 +1,90 @@
+import styled from 'styled-components';
+
+export const StyledContainer = styled.div`
+  @media (max-width: 24.375rem) {
+    width: 21.875rem;
+  }
+
+  width: 79.625rem;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const StyledLabelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StyledLabelTitle = styled.label`
+  @media (max-width: 24.375rem) {
+    ${({ theme }) => theme.typo.caption0};
+  }
+
+  ${({ theme }) => theme.typo.subtitle3};
+  color: ${({ theme }) => theme.color.textPrimary};
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export const StyledLabelDescription = styled.span`
+  /* Soomsil/Drawer/Web/body10 */
+  font-family: 'Spoqa Han Sans Neo';
+  font-size: 0.625rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.3;
+
+  color: ${({ theme }) => theme.color.textSecondary};
+  margin-top: 0.62rem;
+`;
+
+export const StyledTextAreaContainer = styled.div`
+  @media (max-width: 24.375rem) {
+    width: 16rem;
+  }
+
+  width: 61.875rem;
+  display: flex;
+  flex-direction: column;
+`;
+
+interface StyledTextAreaProps {
+  $isWarned?: boolean;
+}
+
+export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
+  @media (max-width: 24.375rem) {
+    ${({ theme }) => theme.typo.caption2};
+  }
+
+  ${({ theme }) => theme.typo.button4};
+  color: ${({ $isWarned, theme }) =>
+    $isWarned ? theme.color.buttonWarned : theme.color.textSecondary};
+
+  resize: none;
+  padding: 0.38rem;
+
+  border: none;
+  border-bottom: 1px solid
+    ${({ $isWarned, theme }) => ($isWarned ? theme.color.buttonWarned : theme.color.buttonDisabled)};
+
+  &:focus {
+    border-bottom: 1px solid
+      ${({ $isWarned, theme }) =>
+        $isWarned ? theme.color.buttonWarned : theme.color.buttonNormalPressed};
+  }
+`;
+
+export const StyledTextAreaLength = styled.span<StyledTextAreaProps>`
+  /* Soomsil/Drawer/Web/body10 */
+  font-size: 0.625rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.3;
+
+  color: ${({ $isWarned, theme }) =>
+    $isWarned ? theme.color.buttonWarned : theme.color.textSecondary};
+  text-align: right;
+`;

--- a/src/drawer/components/TextArea/TextArea.tsx
+++ b/src/drawer/components/TextArea/TextArea.tsx
@@ -36,6 +36,7 @@ export const TextArea = ({ title, description, isWarned, ...props }: TextAreaPro
           onChange={handleTextAreaChange}
           rows={8}
           $isWarned={isWarned}
+          $hasText={textAreaValue.length > 0}
           {...props}
         />
         {isWarned ? (

--- a/src/drawer/components/TextArea/TextArea.tsx
+++ b/src/drawer/components/TextArea/TextArea.tsx
@@ -1,0 +1,51 @@
+import { TextareaHTMLAttributes, useState } from 'react';
+
+import {
+  StyledContainer,
+  StyledLabelContainer,
+  StyledLabelDescription,
+  StyledLabelTitle,
+  StyledTextArea,
+  StyledTextAreaContainer,
+  StyledTextAreaLength,
+} from './TextArea.style';
+
+interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  title: string;
+  description: string;
+  isWarned?: boolean;
+}
+
+export const TextArea = ({ title, description, isWarned, ...props }: TextAreaProps) => {
+  const [textAreaValue, setTextAreaValue] = useState('');
+
+  const handleTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextAreaValue(event.target.value);
+  };
+
+  return (
+    <StyledContainer>
+      <StyledLabelContainer>
+        <StyledLabelTitle htmlFor={title}>{props.required ? `${title} *` : title}</StyledLabelTitle>
+        <StyledLabelDescription>{description}</StyledLabelDescription>
+      </StyledLabelContainer>
+      <StyledTextAreaContainer>
+        <StyledTextArea
+          id={title}
+          value={textAreaValue}
+          onChange={handleTextAreaChange}
+          rows={8}
+          $isWarned={isWarned}
+          {...props}
+        />
+        {isWarned ? (
+          <StyledTextAreaLength $isWarned={true}>*{title}은 필수값입니다.</StyledTextAreaLength>
+        ) : (
+          <StyledTextAreaLength>
+            {textAreaValue.length}/{props.maxLength}
+          </StyledTextAreaLength>
+        )}
+      </StyledTextAreaContainer>
+    </StyledContainer>
+  );
+};

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -1,40 +1,41 @@
 import { Input } from '@/drawer/components/Input/Input';
+import { TextArea } from '@/drawer/components/TextArea/TextArea';
 
 import { StyledContainer, StyledInputContainer } from './Register.style';
 
 export const Register = () => {
   return (
-    <>
-      <StyledContainer>
-        <StyledInputContainer>
-          <Input
-            maxLength={20}
-            title={'서비스 이름'}
-            description={'(최대 20자)'}
-            required={true}
-            isWarned={true}
-          />
+    <StyledContainer>
+      <StyledInputContainer>
+        <Input
+          maxLength={20}
+          title={'서비스 이름'}
+          description={'(최대 20자)'}
+          required={true}
+          isWarned={true}
+        />
 
-          <Input
-            width={79.625}
-            maxLength={20}
-            title={'간단한 설명'}
-            description={'(최대 20자)'}
-            required={true}
-            disabled={true}
-          />
-        </StyledInputContainer>
+        <Input
+          width={79.625}
+          maxLength={20}
+          title={'간단한 설명'}
+          description={'(최대 20자)'}
+          required={true}
+          disabled={true}
+        />
+      </StyledInputContainer>
 
-        <StyledInputContainer>
-          <Input maxLength={100} title={'웹 페이지 링크'} description={'(최대 100자)'} />
+      <TextArea title="내용" description="(최대 5000자)" required={true} maxLength={5000} />
 
-          <Input maxLength={100} title={'Google Play 링크'} description={'(최대 100자)'} />
+      <StyledInputContainer>
+        <Input maxLength={100} title={'웹 페이지 링크'} description={'(최대 100자)'} />
 
-          <Input maxLength={100} title={'App Store 링크'} description={'(최대 100자)'} />
+        <Input maxLength={100} title={'Google Play 링크'} description={'(최대 100자)'} />
 
-          <Input maxLength={100} title={'GitHub 링크'} description={'(최대 100자)'} />
-        </StyledInputContainer>
-      </StyledContainer>
-    </>
+        <Input maxLength={100} title={'App Store 링크'} description={'(최대 100자)'} />
+
+        <Input maxLength={100} title={'GitHub 링크'} description={'(최대 100자)'} />
+      </StyledInputContainer>
+    </StyledContainer>
   );
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #41 
<img width="1485" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/76615094/cc5b01f1-1821-4a7d-aca9-8f2b44fe0133">


### 기존 코드에 영향을 미치지 않는 변경사항

- 서랍장 서비스 등록 페이지에 사용되는 `TextArea` 컴포넌트를 구현했습니다.

### 기존 코드에 영향을 미치는 변경사항

- `Input.tsx` (@Hanna922)
  - `Input` 컴포넌트의 `border-bottom`의 기본 색상을 `buttonNormal`에서 `buttonNormalPressed`로 수정했습니다. (피그마 참고)
  - 지금 `Input` 컴포넌트는 `Input`의 `disabled` 속성이 `true`일 때, `border-bottom`에 `buttonDisabled` 색상을 주고 있는 상태입니다.
  - 그런데 피그마를 보면 텍스트가 있을 때 입력 폼의 `border-bottom` 색상이 `buttonNormalPressed`이고 텍스트가 없을 때 `border-bottom` 색상이 `buttonDisabled`로 되어있어 개인적으로 `disabled` 속성의 차이가 아니라 입력 폼의 텍스트 유무 차이로 인해 `border-bottom` 색상이 변경되는게 맞는거 같은데 한나는 어떻게 생각하는지 궁금합니다🤔
 
## 2️⃣ 알아두시면 좋아요!

- YDS `buttonDisabled` 색상이 잘못된 것 같아요! (https://github.com/yourssu/YDS-React/issues/40)

### 피그마
-  `buttonNormalPressed` - #8E9398
-  `buttonDisabled` - #B5B9BD

### YDS
-  `buttonNormalPressed` - #8E9398
-  `buttonDisabled` - #8E9398

## 3️⃣ 추후 작업

- PR 리뷰 반영하기

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
