### PR TITLE
feat: 링크 유효성 검증 및 등록 페이지 레이아웃 작업

### DIFF
--- a/src/drawer/components/Input/Input.style.ts
+++ b/src/drawer/components/Input/Input.style.ts
@@ -68,13 +68,18 @@ export const StyledInputLength = styled.span<StyledInputProps>`
   text-align: right;
 `;
 
-export const StyledLabelTitle = styled.label`
+interface StyledLabelTitleProps {
+  $isWarned?: boolean;
+}
+
+export const StyledLabelTitle = styled.label<StyledLabelTitleProps>`
   @media (max-width: 30rem) {
     ${({ theme }) => theme.typo.caption0};
   }
 
   ${({ theme }) => theme.typo.subtitle3};
-  color: ${({ theme }) => theme.color.textPrimary};
+  color: ${({ $isWarned, theme }) =>
+    $isWarned ? theme.color.buttonWarned : theme.color.textPrimary};
   word-break: keep-all;
 
   &:hover {

--- a/src/drawer/components/Input/Input.tsx
+++ b/src/drawer/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, useState } from 'react';
+import { InputHTMLAttributes, useMemo, useState } from 'react';
 
 import {
   StyledContainer,
@@ -13,20 +13,37 @@ import {
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   title: string;
   description: string;
-  isWarned?: boolean;
+  validate?: (value: string) => boolean;
 }
 
-export const Input = ({ title, description, isWarned, ...props }: InputProps) => {
+export const Input = ({ title, description, validate, ...props }: InputProps) => {
   const [inputValue, setInputValue] = useState('');
+  const [isWarned, setIsWarned] = useState(false);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
   };
 
+  const checkValid = useMemo(() => {
+    if (validate && validate(inputValue) && inputValue.length > 0) {
+      setIsWarned(true);
+      return <StyledInputLength $isWarned={true}>유효하지 않은 링크입니다.</StyledInputLength>;
+    } else {
+      setIsWarned(false);
+      return (
+        <StyledInputLength>
+          {inputValue.length}/{props.maxLength}
+        </StyledInputLength>
+      );
+    }
+  }, [inputValue, props.maxLength, validate]);
+
   return (
     <StyledContainer>
       <StyledLabelContainer>
-        <StyledLabelTitle htmlFor={title}>{props.required ? `${title} *` : title}</StyledLabelTitle>
+        <StyledLabelTitle htmlFor={title} $isWarned={isWarned}>
+          {props.required ? `${title} *` : title}
+        </StyledLabelTitle>
         <StyledLabelDescription>{description}</StyledLabelDescription>
       </StyledLabelContainer>
       <StyledInputContainer>
@@ -38,13 +55,7 @@ export const Input = ({ title, description, isWarned, ...props }: InputProps) =>
           $hasText={inputValue.length > 0}
           {...props}
         />
-        {isWarned ? (
-          <StyledInputLength $isWarned={true}>*{title}은 필수값입니다.</StyledInputLength>
-        ) : (
-          <StyledInputLength>
-            {inputValue.length}/{props.maxLength}
-          </StyledInputLength>
-        )}
+        {checkValid}
       </StyledInputContainer>
     </StyledContainer>
   );

--- a/src/drawer/components/TextArea/TextArea.style.ts
+++ b/src/drawer/components/TextArea/TextArea.style.ts
@@ -15,13 +15,18 @@ export const StyledLabelContainer = styled.div`
   flex-direction: column;
 `;
 
-export const StyledLabelTitle = styled.label`
+interface StyledLabelTitleProps {
+  $isWarned?: boolean;
+}
+
+export const StyledLabelTitle = styled.label<StyledLabelTitleProps>`
   @media (max-width: 30rem) {
     ${({ theme }) => theme.typo.caption0};
   }
 
   ${({ theme }) => theme.typo.subtitle3};
-  color: ${({ theme }) => theme.color.textPrimary};
+  color: ${({ $isWarned, theme }) =>
+    $isWarned ? theme.color.buttonWarned : theme.color.textPrimary};
 
   &:hover {
     cursor: pointer;
@@ -41,7 +46,7 @@ export const StyledLabelDescription = styled.span`
 `;
 
 export const StyledTextAreaContainer = styled.div`
-  @media (max-width: MOBILE_VIEW_WIDTH) {
+  @media (max-width: 30rem) {
     width: 16rem;
   }
 

--- a/src/drawer/components/TextArea/TextArea.tsx
+++ b/src/drawer/components/TextArea/TextArea.tsx
@@ -26,7 +26,9 @@ export const TextArea = ({ title, description, isWarned, ...props }: TextAreaPro
   return (
     <StyledContainer>
       <StyledLabelContainer>
-        <StyledLabelTitle htmlFor={title}>{props.required ? `${title} *` : title}</StyledLabelTitle>
+        <StyledLabelTitle htmlFor={title} $isWarned={isWarned}>
+          {props.required ? `${title} *` : title}
+        </StyledLabelTitle>
         <StyledLabelDescription>{description}</StyledLabelDescription>
       </StyledLabelContainer>
       <StyledTextAreaContainer>

--- a/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.style.ts
+++ b/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.style.ts
@@ -31,12 +31,13 @@ export const StyledAccordionHeader = styled.div`
 export const StyledAccordionContent = styled.div<{ $isOpen: boolean }>`
   width: 17.5rem;
   color: ${({ theme }) => theme.color.textPrimary};
-  font-family: 'Apple SD Gothic Neo';
+  font-family: 'Spoqa Han Sans Neo';
   font-size: 0.65rem;
   font-style: normal;
   font-weight: 400;
   line-height: 1.3;
   margin-left: 0.5rem;
+  word-break: keep-all;
 
   display: ${({ $isOpen }) => ($isOpen ? 'block' : 'none')};
 `;

--- a/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.tsx
+++ b/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.tsx
@@ -46,15 +46,9 @@ export const WarningAccordion = () => {
         </IconContext.Provider>
       </StyledAccordionHeaderContainer>
       <StyledAccordionContent $isOpen={isAccordionOpen}>
-        게시하는 이미지가 저작권 기타 법령을 위반하지 않는 것을
-        <br />
-        확인하였으며, 숨쉴때 서비스를 통해 공중송신되는 것을 동의합니다.
-        <br />
-        저작권 기타 법령 위반이 확인되었거나 그러한 신고가 접수되는 경우,
-        <br />
-        이미지 교체 통지 또는 게시자의 동의 없이 서비스 삭제가
-        <br />
-        이루어질 수 있음을 알립니다.
+        게시하는 이미지가 저작권 기타 법령을 위반하지 않는 것을 확인하였으며, 숨쉴때 서비스를 통해
+        공중송신되는 것을 동의합니다. 저작권 기타 법령 위반이 확인되었거나 그러한 신고가 접수되는
+        경우, 이미지 교체 통지 또는 게시자의 동의 없이 서비스 삭제가 이루어질 수 있음을 알립니다.
       </StyledAccordionContent>
     </StyledAccordionContainer>
   );

--- a/src/drawer/components/WarningBox/WarningBox.style.ts
+++ b/src/drawer/components/WarningBox/WarningBox.style.ts
@@ -1,11 +1,15 @@
 import styled from 'styled-components';
 
 export const StyledContainer = styled.div`
+  @media (max-width: 30rem) {
+    margin-right: 0rem;
+  }
+
   display: flex;
   flex-direction: column;
   align-items: end;
   gap: 1.06rem;
-  margin-bottom: 2rem;
+  margin-right: 1.2rem;
 `;
 
 export const StyledWarningBoxContainer = styled.div`
@@ -18,7 +22,6 @@ export const StyledWarningBoxContainer = styled.div`
   flex-direction: row;
   gap: 1.27rem;
   align-items: center;
-  margin-right: 1.2rem;
 `;
 
 export const StyledWarningBoxText = styled.div`

--- a/src/drawer/constants/link.constant.ts
+++ b/src/drawer/constants/link.constant.ts
@@ -1,0 +1,25 @@
+export const RESISTER_URL = {
+  WEB: 'https://',
+  GOOGLE_PLAY: 'https://play.google.com/',
+  APP_STORE: 'https://www.apple.com/',
+  GITHUB: 'https://github.com/',
+};
+
+export const LINK = [
+  {
+    name: 'WEB',
+    title: '웹 페이지 링크',
+  },
+  {
+    name: 'GOOGLE_PLAY',
+    title: 'Google Play 링크',
+  },
+  {
+    name: 'APP_STORE',
+    title: 'App Store 링크',
+  },
+  {
+    name: 'GITHUB',
+    title: 'Github 링크',
+  },
+];

--- a/src/drawer/constants/link.constant.ts
+++ b/src/drawer/constants/link.constant.ts
@@ -1,25 +1,25 @@
-export const RESISTER_URL = {
-  WEB: 'https://',
-  GOOGLE_PLAY: 'https://play.google.com/',
-  APP_STORE: 'https://www.apple.com/',
-  GITHUB: 'https://github.com/',
+export const REGISTER_URL = {
+  webpageUrl: 'https://',
+  googlePlayUrl: 'https://play.google.com/',
+  appStoreUrl: 'https://www.apple.com/',
+  githubUrl: 'https://github.com/',
 };
 
 export const LINK = [
   {
-    name: 'WEB',
+    name: 'webpageUrl',
     title: '웹 페이지 링크',
   },
   {
-    name: 'GOOGLE_PLAY',
+    name: 'googlePlayUrl',
     title: 'Google Play 링크',
   },
   {
-    name: 'APP_STORE',
+    name: 'appStoreUrl',
     title: 'App Store 링크',
   },
   {
-    name: 'GITHUB',
+    name: 'githubUrl',
     title: 'Github 링크',
   },
 ];

--- a/src/drawer/pages/Register/Register.style.ts
+++ b/src/drawer/pages/Register/Register.style.ts
@@ -1,14 +1,53 @@
 import styled from 'styled-components';
 
 export const StyledContainer = styled.div`
+  @media (max-width: 30rem) {
+    gap: 1.25rem;
+    padding: 1.5rem 0rem;
+  }
+
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  margin-top: 3.37rem;
+  padding: 3.37rem 0rem;
 `;
 
 export const StyledInputContainer = styled.div`
+  @media (max-width: 30rem) {
+    gap: 0.75rem;
+  }
+
   display: flex;
   flex-direction: column;
   gap: 1.56rem;
+`;
+
+export const StyledRightContainer = styled.div`
+  @media (max-width: 30rem) {
+    margin-right: 0rem;
+  }
+
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 1.2rem;
+`;
+
+export const StyledImportText = styled.p`
+  @media (max-width: 30rem) {
+    /* Soomsil/Drawer/Web/body10 */
+    font-size: 'Spoqa Han Sans Neo';
+    font-size: 0.625rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 1.3;
+  }
+
+  ${({ theme }) => theme.typo.subtitle3};
+  color: ${({ theme }) => theme.color.textPrimary};
+  text-align: right;
+  white-space: pre-wrap;
+
+  &:hover {
+    cursor: pointer;
+  }
 `;

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -1,47 +1,80 @@
+import { BoxButton } from '@yourssu/design-system-react';
+
 import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
 import { Input } from '@/drawer/components/Input/Input';
 import { TextArea } from '@/drawer/components/TextArea/TextArea';
 import { WarningBox } from '@/drawer/components/WarningBox/WarningBox';
+import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
 
-import { StyledContainer, StyledInputContainer } from './Register.style';
+import {
+  StyledContainer,
+  StyledImportText,
+  StyledInputContainer,
+  StyledRightContainer,
+} from './Register.style';
 
 export const Register = () => {
   return (
     <StyledContainer>
       <StyledInputContainer>
-        <Input
-          maxLength={20}
-          title={'서비스 이름'}
-          description={'(최대 20자)'}
-          required={true}
-          isWarned={true}
-        />
+        <StyledRightContainer>
+          <StyledImportText>별표 표시 * 는 필수 입력란</StyledImportText>
+        </StyledRightContainer>
 
-        <Input
-          width={79.625}
-          maxLength={20}
-          title={'간단한 설명'}
-          description={'(최대 20자)'}
-          required={true}
-          disabled={true}
-        />
+        <Input maxLength={20} title={'서비스 이름'} description={'(최대 20자)'} required={true} />
+
+        <Input maxLength={20} title={'간단한 설명'} description={'(최대 20자)'} required={true} />
       </StyledInputContainer>
 
-      <TextArea title="내용" description="(최대 5000자)" required={true} maxLength={5000} />
+      <TextArea maxLength={5000} title={'내용'} description={'(최대 5000자)'} required={true} />
 
       <CategoryWithoutAll />
 
       <StyledInputContainer>
-        <Input maxLength={100} title={'웹 페이지 링크'} description={'(최대 100자)'} />
+        <StyledRightContainer>
+          <StyledImportText>
+            {window.innerWidth < MOBILE_VIEW_WIDTH
+              ? '웹 페이지, Google play, App store, Github\n링크 중 하나는 필수 기재 *'
+              : '웹 페이지, Google play, App store, Github 링크 중 하나는 필수 기재 *'}
+          </StyledImportText>
+        </StyledRightContainer>
 
-        <Input maxLength={100} title={'Google Play 링크'} description={'(최대 100자)'} />
+        <Input
+          maxLength={100}
+          title={'웹 페이지 링크'}
+          description={'(최대 100자)'}
+          validate={(value) => !value.startsWith('https://')}
+        />
 
-        <Input maxLength={100} title={'App Store 링크'} description={'(최대 100자)'} />
+        <Input
+          maxLength={100}
+          title={'Google Play 링크'}
+          description={'(최대 100자)'}
+          validate={(value) => !value.startsWith('https://play.google.com/')}
+        />
 
-        <Input maxLength={100} title={'GitHub 링크'} description={'(최대 100자)'} />
+        <Input
+          maxLength={100}
+          title={'App Store 링크'}
+          description={'(최대 100자)'}
+          validate={(value) => !value.startsWith('https://www.apple.com/')}
+        />
+
+        <Input
+          maxLength={100}
+          title={'GitHub 링크'}
+          description={'(최대 100자)'}
+          validate={(value) => !value.startsWith('https://github.com/')}
+        />
       </StyledInputContainer>
 
       <WarningBox />
+
+      <StyledRightContainer>
+        <BoxButton size={'medium'} variant={'filled'} rounding={4} width="8.125rem">
+          서비스 등록
+        </BoxButton>
+      </StyledRightContainer>
     </StyledContainer>
   );
 };

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -4,6 +4,7 @@ import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/Categ
 import { Input } from '@/drawer/components/Input/Input';
 import { TextArea } from '@/drawer/components/TextArea/TextArea';
 import { WarningBox } from '@/drawer/components/WarningBox/WarningBox';
+import { LINK, RESISTER_URL } from '@/drawer/constants/link.constant';
 import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
 
 import {
@@ -14,6 +15,10 @@ import {
 } from './Register.style';
 
 export const Register = () => {
+  const validateLink = (name: string, value: string) => {
+    return !value.startsWith(RESISTER_URL[name as keyof typeof RESISTER_URL]);
+  };
+
   return (
     <StyledContainer>
       <StyledInputContainer>
@@ -39,33 +44,15 @@ export const Register = () => {
           </StyledImportText>
         </StyledRightContainer>
 
-        <Input
-          maxLength={100}
-          title={'웹 페이지 링크'}
-          description={'(최대 100자)'}
-          validate={(value) => !value.startsWith('https://')}
-        />
-
-        <Input
-          maxLength={100}
-          title={'Google Play 링크'}
-          description={'(최대 100자)'}
-          validate={(value) => !value.startsWith('https://play.google.com/')}
-        />
-
-        <Input
-          maxLength={100}
-          title={'App Store 링크'}
-          description={'(최대 100자)'}
-          validate={(value) => !value.startsWith('https://www.apple.com/')}
-        />
-
-        <Input
-          maxLength={100}
-          title={'GitHub 링크'}
-          description={'(최대 100자)'}
-          validate={(value) => !value.startsWith('https://github.com/')}
-        />
+        {LINK.map((link) => (
+          <Input
+            key={link.name}
+            maxLength={100}
+            title={link.title}
+            description={'(최대 100자)'}
+            validate={(value) => validateLink(link.name, value)}
+          />
+        ))}
       </StyledInputContainer>
 
       <WarningBox />

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -4,7 +4,7 @@ import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/Categ
 import { Input } from '@/drawer/components/Input/Input';
 import { TextArea } from '@/drawer/components/TextArea/TextArea';
 import { WarningBox } from '@/drawer/components/WarningBox/WarningBox';
-import { LINK, RESISTER_URL } from '@/drawer/constants/link.constant';
+import { LINK, REGISTER_URL } from '@/drawer/constants/link.constant';
 import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
 
 import {
@@ -16,7 +16,7 @@ import {
 
 export const Register = () => {
   const validateLink = (name: string, value: string) => {
-    return !value.startsWith(RESISTER_URL[name as keyof typeof RESISTER_URL]);
+    return !value.startsWith(REGISTER_URL[name as keyof typeof REGISTER_URL]);
   };
 
   return (


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #68 

### 기존 코드에 영향을 미치는 변경사항
- 4가지 링크 별 유효성을 검증하는 로직을 추가하였습니다.
  - input 내 checkValid function
  - 불필요한 리렌더링을 막기 위해 useMemo 사용
  - 정규식은 따로 추가하지 않고, 링크의 시작 부분만 걸어두었는데, 혹시 부족할까요....? 의견 대환영입니다~!
- '등록' 버튼 클릭 시 띄우는 validation 디자인은 react-hook-form 작업과 함께 해야할 수도 있을 것 같아서 우선 isWarned props 작업만 해두었습니다.
- @2wndrhs TextArea의 validation(warning)의 경우 label도 함께 변경되어야 해서 적용해두었습니다.
- @seocylucky WarningBox의 레이아웃을 살짝 수정하였고, WarningAccordian에 word-break를 설정했습니다.

### 실행화면
|Web1|Web2|
|--|--|
|![image](https://github.com/yourssu/Soomsil-Web/assets/84809236/daa5c8ac-3e5e-4a1e-a696-ede167e0508d)|![image](https://github.com/yourssu/Soomsil-Web/assets/84809236/32ca115b-e1ab-4e5a-a5e9-65b15ddb55c7)|

|Mobile1|Mobile2|
|--|--|
|![image](https://github.com/yourssu/Soomsil-Web/assets/84809236/99e94878-0d07-4527-bd1a-25e1ee0ff3de)|![image](https://github.com/yourssu/Soomsil-Web/assets/84809236/7f2be4c6-5bee-4905-b7c3-f6b6f685b458)|

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
