### PR TITLE
feat: 서랍장 서비스 등록 페이지 반응형 헤더 구현

### DIFF
--- a/src/drawer/components/Header/Header.style.ts
+++ b/src/drawer/components/Header/Header.style.ts
@@ -6,8 +6,7 @@ export const StyledHeader = styled.header`
   align-items: center;
   width: 100%;
   height: 4rem;
-  /* TODO: 추후 반응형 적용 필요 */
-  padding-right: 10%;
+  padding-right: 10vw;
   position: sticky;
   top: 0;
   background-color: ${({ theme }) => theme.color.bgNormal};
@@ -17,14 +16,13 @@ export const StyledHeader = styled.header`
 `;
 
 export const StyledHeaderLogo = styled(Link)`
-  margin-left: 2.5rem;
   display: flex;
+  margin-left: 2.5rem;
 `;
 
 export const StyledHeaderTabs = styled.nav`
   display: flex;
-  /* TODO: 추후 반응형 적용 필요 */
-  margin-left: 10%;
+  margin-left: 7.5rem;
 `;
 
 export const StyledHeaderTab = styled(NavLink)`
@@ -53,10 +51,9 @@ export const StyledHeaderTab = styled(NavLink)`
 
 export const StyledHeaderSearchContainer = styled.div`
   display: flex;
-  /* TODO: 추후 반응형 적용 필요 */
-  width: 30%;
+  width: 30vw;
   height: 2.75rem;
-  border: 1px solid ${({ theme }) => theme.color.borderThick};
+  border: 1px solid ${({ theme }) => theme.color.buttonNormalPressed};
   border-radius: 6.25rem;
   padding: 0.75rem 1rem;
   gap: 0.25rem;

--- a/src/drawer/components/Header/Header.tsx
+++ b/src/drawer/components/Header/Header.tsx
@@ -13,12 +13,12 @@ import {
   StyledHeaderSearchInput,
 } from './Header.style';
 
-const Header = () => {
+export const Header = () => {
   const theme = useTheme();
 
   return (
     <StyledHeader>
-      <StyledHeaderLogo to="/drawer">
+      <StyledHeaderLogo to="/">
         <img src={soomsil} alt="soomsil" />
       </StyledHeaderLogo>
       <StyledHeaderTabs>
@@ -51,5 +51,3 @@ const Header = () => {
     </StyledHeader>
   );
 };
-
-export default Header;

--- a/src/drawer/components/Header/MobileRegisterHeader.style.ts
+++ b/src/drawer/components/Header/MobileRegisterHeader.style.ts
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const StyledContainer = styled.header`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.75rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+
+  background-color: ${({ theme }) => theme.color.bgNormal};
+  border-bottom: 1px solid ${({ theme }) => theme.color.borderNormal};
+`;
+
+export const StyledHeaderTab = styled(Link)`
+  /* Soomsil/Drawer/Web/body10 */
+  font-family: 'Spoqa Han Sans Neo';
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 130%;
+  letter-spacing: 0.25px;
+
+  position: relative;
+
+  padding: 0.96875rem; 1.5rem;
+
+  color: ${({ theme }) => theme.color.textTertiary};
+
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 0;
+    width: 60%;
+    height: 0.25rem;
+    border-radius: 0.5rem 0.5rem 0 0;
+    background-color: ${({ theme }) => theme.color.textPointed};
+  }
+`;

--- a/src/drawer/components/Header/MobileRegisterHeader.tsx
+++ b/src/drawer/components/Header/MobileRegisterHeader.tsx
@@ -1,0 +1,32 @@
+import { IcPersoncircleLine, IconContext } from '@yourssu/design-system-react';
+import { Link } from 'react-router-dom';
+import { useTheme } from 'styled-components';
+
+import soomsil from '@/assets/soomsil.svg';
+import { FlexGrowItem } from '@/components/FlexContainer/FlexContainer';
+
+import { StyledContainer, StyledHeaderTab } from './MobileRegisterHeader.style';
+
+export const MobileRegisterHeader = () => {
+  const theme = useTheme();
+
+  return (
+    <StyledContainer>
+      <Link to="/">
+        <img src={soomsil} alt="soomsil" width={95} />
+      </Link>
+      <FlexGrowItem proportion={1} />
+      <StyledHeaderTab to="register">서비스 등록</StyledHeaderTab>
+      <button style={{ marginLeft: '0.5rem', height: '2rem' }}>
+        <IconContext.Provider
+          value={{
+            color: theme.color.textPointed,
+            size: '2rem',
+          }}
+        >
+          <IcPersoncircleLine />
+        </IconContext.Provider>
+      </button>
+    </StyledContainer>
+  );
+};

--- a/src/drawer/components/Layout/Layout.style.ts
+++ b/src/drawer/components/Layout/Layout.style.ts
@@ -8,5 +8,4 @@ export const StyledLayout = styled.div`
   align-items: center;
   position: relative;
   padding-bottom: 80px;
-  overflow-x: hidden;
 `;

--- a/src/drawer/components/Layout/Layout.tsx
+++ b/src/drawer/components/Layout/Layout.tsx
@@ -1,14 +1,22 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
+
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 
 import { Footer } from '../Footer/Footer';
-import Header from '../Header/Header';
+import { Header } from '../Header/Header';
+import { MobileRegisterHeader } from '../Header/MobileRegisterHeader';
 
 import { StyledLayout } from './Layout.style';
 
 export const Layout = () => {
+  const location = useLocation();
+  const isMobile = useMediaQuery('(max-width: 30rem)');
+
+  const isMobileRegisterRoute = isMobile && location.pathname === '/drawer/register';
+
   return (
     <StyledLayout>
-      <Header />
+      {isMobileRegisterRoute ? <MobileRegisterHeader /> : <Header />}
       <Outlet />
       <Footer />
     </StyledLayout>

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -40,7 +40,7 @@ import {
 } from './ServiceDetail.style';
 
 export const ServiceDetail = () => {
-  const { serviceId } = useParams();
+  // const { serviceId } = useParams();
   const theme = useTheme();
 
   const scrollRef = useRef<HTMLDivElement | null>(null);

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export const useMediaQuery = (query: string) => {
+  const mediaQuery = window.matchMedia(query);
+  const [isMatch, setIsMatch] = useState(mediaQuery.matches);
+
+  useEffect(() => {
+    const listener = () => setIsMatch(mediaQuery.matches);
+
+    mediaQuery.addEventListener('change', listener);
+
+    return () => mediaQuery.removeEventListener('change', listener);
+  }, [mediaQuery]);
+
+  return isMatch;
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #73 
<img width="381" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/76615094/8dc9b6c5-6ee2-470c-ae55-cf745925fb40">


### 기존 코드에 영향을 미치지 않는 변경사항
- 모바일 서랍장 서비스 등록 페이지에 사용되는 `MobileRegisterHeader` 컴포넌트를 구현했습니다.
- 주어진 미디어 쿼리 문자열이 현재 화면 사이즈와 일치하는지를 반환하는 `useMediaQuery()` 커스텀 훅을 구현했습니다.

### 기존 코드에 영향을 미치는 변경사항
- `Layout.tsx`
  - 모바일 && 서비스 등록 페이지일때 선택적으로 `MobileRegisterHeader`를 보여줄 수 있도록 수정했습니다.

### 버그 픽스
- 스크롤을 내려도 헤더가 상단에 붙어있지 않는 문제 (@Hanna922)
  - `Header`의 부모 요소인 `Layout` 컴포넌트에 선언된 `overflow-x: hidden` 때문에 `Header`의 `position: sticky`가 정상적으로 동작하지 않음 -> `Layout`에서 `overflow-x: hidden` 제거
  - 관련 이슈 - https://github.com/w3c/csswg-drafts/issues/865

## 2️⃣ 알아두시면 좋아요!
- 헤더의 `soomsil` 로고 클릭 시 `/drawer`가 아닌 `/`로 라우팅 되도록 수정했습니다. 

## 3️⃣ 추후 작업
- PR 리뷰 반영하기

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
