### PR TITLE
feat: 카테고리 및 경고문 validation isWarned 추가

### DIFF
--- a/src/drawer/components/Category/Category.tsx
+++ b/src/drawer/components/Category/Category.tsx
@@ -39,7 +39,13 @@ export const Category = ({ isAll }: IsAllProps) => {
         <StyledCategoryContainer>
           <div>카테고리 유형</div>
           {CategoryList.map(({ id, title }) => (
-            <CheckBox key={id}>{title}</CheckBox>
+            <CheckBox
+              key={id}
+              isSelected={selectedCategory === id}
+              onChange={() => handleCategorySelect(id)}
+            >
+              {title}
+            </CheckBox>
           ))}
         </StyledCategoryContainer>
       ) : (

--- a/src/drawer/components/Category/Category.tsx
+++ b/src/drawer/components/Category/Category.tsx
@@ -9,27 +9,27 @@ interface IsAllProps {
 }
 
 interface CategoryProps {
-  id: number;
+  category: string;
   title: string;
   subcategories?: string;
 }
 
 const CategoryList: CategoryProps[] = [
-  { id: 1, title: '전체' },
-  { id: 2, title: '교내생활' },
-  { id: 3, title: '취미', subcategories: '(음악, 스포츠, 게임, 여행)' },
-  { id: 4, title: '건강', subcategories: '(건강 및 피트니스, 의료)' },
-  { id: 5, title: 'IT', subcategories: '(AI, 개발자, 디자인)' },
-  { id: 6, title: '지식', subcategories: '(비즈니스, 교육, 뉴스, 금융)' },
-  { id: 7, title: '라이프스타일', subcategories: '(소셜 네트워킹, 미디어, 일상)' },
-  { id: 8, title: '기타' },
+  { category: '', title: '전체' },
+  { category: 'CAMPUS', title: '교내생활' },
+  { category: 'HOBBY', title: '취미', subcategories: '(음악, 스포츠, 게임, 여행)' },
+  { category: 'HEALTH', title: '건강', subcategories: '(건강 및 피트니스, 의료)' },
+  { category: 'IT', title: 'IT', subcategories: '(AI, 개발자, 디자인)' },
+  { category: 'KNOWLEDGE', title: '지식', subcategories: '(비즈니스, 교육, 뉴스, 금융)' },
+  { category: 'LIFESTYLE', title: '라이프스타일', subcategories: '(소셜 네트워킹, 미디어, 일상)' },
+  { category: 'ETC', title: '기타' },
 ];
 
 export const Category = ({ isAll }: IsAllProps) => {
-  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
-  const handleCategorySelect = (categoryId: number) => {
-    setSelectedCategory((prev) => (prev === categoryId ? null : categoryId));
+  const handleCategorySelect = (category: string) => {
+    setSelectedCategory((prev) => (prev === category ? null : category));
   };
 
   return (
@@ -38,11 +38,11 @@ export const Category = ({ isAll }: IsAllProps) => {
         /* isAll이 true일 때 - 사이드에 위치한 카테고리*/
         <StyledCategoryContainer>
           <div>카테고리 유형</div>
-          {CategoryList.map(({ id, title }) => (
+          {CategoryList.map(({ category, title }) => (
             <CheckBox
-              key={id}
-              isSelected={selectedCategory === id}
-              onChange={() => handleCategorySelect(id)}
+              key={category}
+              isSelected={selectedCategory === category}
+              onChange={() => handleCategorySelect(category)}
             >
               {title}
             </CheckBox>
@@ -51,12 +51,12 @@ export const Category = ({ isAll }: IsAllProps) => {
       ) : (
         /* isAll이 false일 때 - 등록 페이지에 위치한 카테고리*/
         <StyledCategoryWithoutAllContainer>
-          {CategoryList.slice(1).map(({ id, title, subcategories }) => (
+          {CategoryList.slice(1).map(({ category, title, subcategories }) => (
             <CheckBox
               size="medium"
-              key={id}
-              isSelected={selectedCategory === id}
-              onChange={() => handleCategorySelect(id)}
+              key={category}
+              isSelected={selectedCategory === category}
+              onChange={() => handleCategorySelect(category)}
             >{`${title} ${subcategories ?? ''}`}</CheckBox>
           ))}
         </StyledCategoryWithoutAllContainer>

--- a/src/drawer/components/CategoryWithoutAll/CategoryWithoutAll.style.ts
+++ b/src/drawer/components/CategoryWithoutAll/CategoryWithoutAll.style.ts
@@ -17,12 +17,17 @@ export const StyledCategoryContainer = styled.div`
   flex-direction: column;
 `;
 
-export const StyledCategoryTitle = styled.div`
+interface StyledCategoryTitleProps {
+  $isWarned?: boolean;
+}
+
+export const StyledCategoryTitle = styled.div<StyledCategoryTitleProps>`
   @media (max-width: 30rem) {
     ${({ theme }) => theme.typo.caption0};
   }
   ${({ theme }) => theme.typo.subtitle3};
-  color: ${({ theme }) => theme.color.textPrimary};
+  color: ${({ $isWarned, theme }) =>
+    $isWarned ? theme.color.buttonWarned : theme.color.textPrimary};
   word-break: keep-all;
 `;
 

--- a/src/drawer/components/CategoryWithoutAll/CategoryWithoutAll.tsx
+++ b/src/drawer/components/CategoryWithoutAll/CategoryWithoutAll.tsx
@@ -7,11 +7,15 @@ import {
   StyledCategoryWithoutAllContainer,
 } from './CategoryWithoutAll.style';
 
-export const CategoryWithoutAll = () => {
+interface CategoryWithoutAllProps {
+  isWarned?: boolean;
+}
+
+export const CategoryWithoutAll = ({ isWarned }: CategoryWithoutAllProps) => {
   return (
     <StyledCategoryWithoutAllContainer>
       <StyledCategoryContainer>
-        <StyledCategoryTitle>카테고리 *</StyledCategoryTitle>
+        <StyledCategoryTitle $isWarned={isWarned}>카테고리 *</StyledCategoryTitle>
         <StyledCategoryDescription>(중복 선택 불가)</StyledCategoryDescription>
       </StyledCategoryContainer>
       <Category isAll={false} />

--- a/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.style.ts
+++ b/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.style.ts
@@ -1,10 +1,17 @@
 import styled from 'styled-components';
 
-export const StyledAccordionContainer = styled.div`
+interface StyledAccordionBoxProps {
+  $isWarned?: boolean;
+}
+
+export const StyledAccordionContainer = styled.div<StyledAccordionBoxProps>`
   width: 21.875rem;
   height: fit-content;
   border-radius: 0.75rem;
   background: ${({ theme }) => theme.color.buttonDisabledBG};
+  border: 1px solid
+    ${({ $isWarned, theme }) =>
+      $isWarned ? theme.color.buttonWarned : theme.color.buttonDisabledBG};
   padding-left: 1.12rem;
   padding-top: 0.69rem;
   padding-right: 1.25rem;

--- a/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.tsx
+++ b/src/drawer/components/WarningBox/WarningAccordion/WarningAccordion.tsx
@@ -15,7 +15,11 @@ import {
   StyledAccordionHeaderContainer,
 } from './WarningAccordion.style';
 
-export const WarningAccordion = () => {
+interface WarningAccordionProps {
+  isWarned?: boolean;
+}
+
+export const WarningAccordion = ({ isWarned }: WarningAccordionProps) => {
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
   const theme = useTheme();
 
@@ -23,7 +27,7 @@ export const WarningAccordion = () => {
     setIsAccordionOpen(!isAccordionOpen);
   };
   return (
-    <StyledAccordionContainer>
+    <StyledAccordionContainer $isWarned={isWarned}>
       <StyledAccordionHeaderContainer onClick={handleOpenAccordion}>
         <IconContext.Provider
           value={{

--- a/src/drawer/components/WarningBox/WarningBox.style.ts
+++ b/src/drawer/components/WarningBox/WarningBox.style.ts
@@ -12,11 +12,18 @@ export const StyledContainer = styled.div`
   margin-right: 1.2rem;
 `;
 
-export const StyledWarningBoxContainer = styled.div`
+interface StyledWarningBoxProps {
+  $isWarned?: boolean;
+}
+
+export const StyledWarningBoxContainer = styled.div<StyledWarningBoxProps>`
   width: 62.5rem;
   height: 4.8125rem;
   border-radius: 0.75rem;
   background: ${({ theme }) => theme.color.buttonDisabledBG};
+  border: 1px solid
+    ${({ $isWarned, theme }) =>
+      $isWarned ? theme.color.buttonWarned : theme.color.buttonDisabledBG};
   padding-left: 1.35rem;
   display: flex;
   flex-direction: row;

--- a/src/drawer/components/WarningBox/WarningBox.tsx
+++ b/src/drawer/components/WarningBox/WarningBox.tsx
@@ -12,7 +12,11 @@ import {
   StyledWarningBoxText,
 } from './WarningBox.style';
 
-export const WarningBox = () => {
+interface WarningBoxProps {
+  isWarned?: boolean;
+}
+
+export const WarningBox = ({ isWarned }: WarningBoxProps) => {
   const [isMobileView, setIsMobileView] = useState(window.innerWidth <= MOBILE_VIEW_WIDTH);
   const theme = useTheme();
 
@@ -32,9 +36,9 @@ export const WarningBox = () => {
   return (
     <StyledContainer>
       {isMobileView ? (
-        <WarningAccordion />
+        <WarningAccordion isWarned={isWarned} />
       ) : (
-        <StyledWarningBoxContainer>
+        <StyledWarningBoxContainer $isWarned={isWarned}>
           <IconContext.Provider
             value={{
               color: theme.color.buttonWarned,


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
카테고리와 경고문 validation isWarned 시 작업을 했습니다.

- resolved #69 

<img width="833" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/94633589/eb1f70d2-4680-4f94-98a0-da6b07526dca">
<img width="301" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/94633589/96bf5e98-47d1-46f1-a1e9-4621c4d66739">
<img width="301" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/94633589/1e67edb1-af52-40ed-88c9-35788bca3a17">

## 2️⃣ 알아두시면 좋아요!
사이드용 전체 포함 카테고리 중복 선택 못하게 수정했습니다!

## 3️⃣ 추후 작업
서비스 등록 버튼을 누르고 나서 validation이 작동되게 하는거라 일단 다른 작업은 더 안했는데 더 필요한 부분 있을까요?! 

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
