### PR TITLE
refactor: 내 서랍장 페이지 초기 currentTab 설정 방식 수정

### DIFF
--- a/src/drawer/pages/MyDrawer/MyDrawer.tsx
+++ b/src/drawer/pages/MyDrawer/MyDrawer.tsx
@@ -27,10 +27,9 @@ export const MyDrawer = () => {
     return tab === 'STAR' || tab === 'MYDRAWER';
   }
 
-  const handleClickTab = (event: React.MouseEvent<HTMLButtonElement>) => {
-    const target = event.target as HTMLButtonElement;
-    setCurrentTab(target.name as TabType);
-    setSearchParams({ tab: target.name });
+  const handleClickTab = (clickedTab: TabType) => {
+    setCurrentTab(clickedTab);
+    setSearchParams({ tab: clickedTab });
   };
 
   return (
@@ -38,19 +37,17 @@ export const MyDrawer = () => {
       <StyledTabWrapper>
         <Button
           text={'Stars'}
-          name={'STAR'}
           isFilled={currentTab === 'STAR'}
-          onClick={(event) => {
-            handleClickTab(event);
+          onClick={() => {
+            handleClickTab('STAR');
           }}
         />
         <Spacing direction={'horizontal'} size={16} />
         <Button
           text={'My Products'}
-          name={'MYDRAWER'}
           isFilled={currentTab === 'MYDRAWER'}
-          onClick={(event) => {
-            handleClickTab(event);
+          onClick={() => {
+            handleClickTab('MYDRAWER');
           }}
         />
       </StyledTabWrapper>

--- a/src/drawer/pages/MyDrawer/MyDrawer.tsx
+++ b/src/drawer/pages/MyDrawer/MyDrawer.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { useSearchParams } from 'react-router-dom';
+
 import Spacing from '@/components/Spacing/Spacing';
 import { Button } from '@/drawer/components/Button/Button';
 import { CardLayout } from '@/drawer/components/CardLayout/CardLayout';
@@ -14,11 +16,24 @@ const Dummy = Array.from({ length: 12 }).map((_, index) => index);
 export type TabType = 'STAR' | 'MYDRAWER';
 
 export const MyDrawer = () => {
-  const [currentTab, setCurrentTab] = useState<TabType>('STAR');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab = searchParams.get('tab');
+
+  const [currentTab, setCurrentTab] = useState<TabType>(getTabFromURL() || 'STAR');
+
+  function isTabType(tab: string): tab is TabType {
+    return tab === 'STAR' || tab === 'MYDRAWER';
+  }
+
+  function getTabFromURL(): TabType | null {
+    if (initialTab && isTabType(initialTab)) return initialTab;
+    else return null;
+  }
 
   const handleClickTab = (event: React.MouseEvent<HTMLButtonElement>) => {
     const target = event.target as HTMLButtonElement;
     setCurrentTab(target.name as TabType);
+    setSearchParams({ tab: target.name });
   };
 
   return (

--- a/src/drawer/pages/MyDrawer/MyDrawer.tsx
+++ b/src/drawer/pages/MyDrawer/MyDrawer.tsx
@@ -19,15 +19,12 @@ export const MyDrawer = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialTab = searchParams.get('tab');
 
-  const [currentTab, setCurrentTab] = useState<TabType>(getTabFromURL() || 'STAR');
+  const [currentTab, setCurrentTab] = useState<TabType>(
+    isTabType(initialTab) ? initialTab : 'STAR'
+  );
 
-  function isTabType(tab: string): tab is TabType {
+  function isTabType(tab: string | null): tab is TabType {
     return tab === 'STAR' || tab === 'MYDRAWER';
-  }
-
-  function getTabFromURL(): TabType | null {
-    if (initialTab && isTabType(initialTab)) return initialTab;
-    else return null;
   }
 
   const handleClickTab = (event: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #87

### 기존 코드에 영향을 미치지 않는 변경사항

#### 이전 코드 동작
그냥 `STAR`로 시작한다 무조건 선택권 그런 거 없음

#### 현재 코드 동작
1. url에서 `tab` 부분을 가져온다
2. `TabType`이 맞으면 해당 값을 `currentTab`의 초기값으로 쓴다
3. `TabType`이 아니거나 null인 경우 `STAR`를 초기값으로 쓴다


![tab](https://github.com/yourssu/Soomsil-Web/assets/87255462/e025b560-1698-4f91-b21a-05b76d137eb9)

움짤에서 확인할 부분
1. 페이지 진입 시 url에 tab 값이 없으면 star로 시작
2. currentTab 바뀔 때마다 url 바뀜
3. my product 선택 상태에서 다른 페이지 갔다가 - 뒤로 가기로 돌아오면 - my product로 선택된 상태

## 3️⃣ 추후 작업
- PR 리뷰 기반 수정

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
