### PR TITLE
fix: 이미지 첨부 안되는 버그 해결

### DIFF
--- a/src/drawer/components/OverviewImage/OverviewImage.tsx
+++ b/src/drawer/components/OverviewImage/OverviewImage.tsx
@@ -18,9 +18,13 @@ export const OverviewImage = ({ isWarned }: OverviewProps) => {
   const MAX_FILE_COUNT = 5;
 
   const handleFileChange = (file: File | undefined, index: number) => {
-    setFiles(
-      (prevFiles) => prevFiles.map((prevFile, i) => (i === index ? file : prevFile)) as File[]
-    );
+    setFiles((prevFiles) => {
+      const newFiles = [...prevFiles];
+      if (file !== undefined) {
+        newFiles[index] = file;
+      }
+      return newFiles;
+    });
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
소개 이미지 첨부가 되지 않는 버그를 해결했습니다.
- resolved #89 

### 버그 픽스
문제는 OverviewImage.tsx 파일에 `handleFileChange`!!!!!!!!였습니다.

기존 코드에서 map 함수를 돌리는데 prevFiles 배열이 빈배열인 상태에서 map을 돌려버려 생긴... 버그였습니다.
아무 생각 없이 코멘트 반영하다가 버그 생긴걸 놓쳤었네요 반성중,,,
빈배열에서 특정 인덱스에 값을 넣어서 반환하도록 코드 수정했습니다.
이제 값은 잘 나올겁니다!

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
