### PR TITLE
feat: 이미지 첨부 시, 이미지 파일만 첨부될 수 있도록 조건 추가

### DIFF
--- a/src/drawer/components/OverviewImage/OverviewImage.tsx
+++ b/src/drawer/components/OverviewImage/OverviewImage.tsx
@@ -24,8 +24,10 @@ export const OverviewImage = () => {
   const handleFileChange = (file: File | undefined, index: number) => {
     setFiles((prevFiles) => {
       const newFiles = [...prevFiles];
-      if (file !== undefined) {
+      if (file && file.type.substring(0, 5) === 'image') {
         newFiles[index] = file;
+      } else {
+        alert('이미지 파일을 첨부해주세요.');
       }
       return newFiles;
     });

--- a/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
+++ b/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
@@ -18,7 +18,7 @@ interface StyledThumbnailProps {
 }
 
 export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
-  const { register, formState, getValues } = useFormContext();
+  const { register, formState, getValues, setValue } = useFormContext();
   const { onChange, ref } = register(name, { required: true });
 
   const [postImg, setPostImg] = useState<File | null>();
@@ -33,6 +33,8 @@ export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
       if (file && file.type.substring(0, 5) === 'image') {
         setPostImg(file);
       } else {
+        alert('이미지 파일을 첨부해주세요.');
+        setValue(name, null);
         setPostImg(null);
       }
     }

--- a/src/drawer/pages/Ranking/Ranking.tsx
+++ b/src/drawer/pages/Ranking/Ranking.tsx
@@ -34,7 +34,6 @@ export const Ranking = () => {
             />
           </StyledBetweenContainer>
           <StyledCardContainer>
-            {/* 추후 card id로 map key index 수정 필요 */}
             {Array.from({ length: 3 }).map((_, index) => (
               <BigDrawerCard
                 key={index}
@@ -63,7 +62,6 @@ export const Ranking = () => {
             />
           </StyledBetweenContainer>
           <StyledCardContainer>
-            {/* 추후 card id로 map key index 수정 필요 */}
             {Array.from({ length: 3 }).map((_, index) => (
               <BigDrawerCard
                 key={index}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
소개 이미지 첨부 시, 이미지 파일만 첨부될 수 있도록 조건 추가하였습니다.

- resolved #100 

```ts
  const handleFileChange = (file: File | undefined, index: number) => {
    setFiles((prevFiles) => {
      const newFiles = [...prevFiles];
      if (file && file.type.substring(0, 5) === 'image') {
        newFiles[index] = file;
      } else {
        alert('이미지 파일을 첨부해주세요.');
      }
      return newFiles;
    });
  };
```

### 질문
이미지 파일 외의 것을 만약 사용자가 체크를 할 때, 일단 alert 처리를 하긴 했는데 괜찮을까용 함 여쭤볼까요?! 
일단 고정적으로 image류만 고를 수 있게 accept="image/*" 처리하긴 했는데 어떤 경우에는 저게 안먹는 경우도 있다고 해서 alert 처리 넣은 거긴 한데 다른 의견 있으신 분들 의견 주시면 감사하겠습니다!!!!

전에 있던 pr에 달까 했는데 최신 develop 브랜치에서 하는게 더 편할 것 같아서 그냥 새로 파서 작업했습니다ㅎㅎ

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
