### PR TITLE
feat: 서랍장 상세 페이지 API 연결

### DIFF
--- a/src/drawer/apis/drawerClient.ts
+++ b/src/drawer/apis/drawerClient.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const drawerClient = axios.create({
+  baseURL: 'https://test.ground.yourssu.com/ground',
+});

--- a/src/drawer/apis/drawerClient.ts
+++ b/src/drawer/apis/drawerClient.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export const drawerClient = axios.create({
-  baseURL: 'https://test.ground.yourssu.com/ground',
+  baseURL: import.meta.env.VITE_API_DRAWER_URL,
 });

--- a/src/drawer/apis/getProductByProvider.ts
+++ b/src/drawer/apis/getProductByProvider.ts
@@ -2,9 +2,19 @@ import { ProductResponses } from '../types/product.type';
 
 import { drawerClient } from './drawerClient';
 
-export const getProductByProvider = async (providerId: string): Promise<ProductResponses> => {
-  const { data } = await drawerClient.get(
-    `/v2/drawer?responseType=WEB&providerId=${providerId}&page=1`
-  );
+export const getProductByProvider = async ({
+  providerId,
+  page = 1,
+}: {
+  providerId: string;
+  page?: number;
+}): Promise<ProductResponses> => {
+  const { data } = await drawerClient.get('/v2/drawer', {
+    params: {
+      responseType: 'WEB',
+      providerId,
+      page,
+    },
+  });
   return data;
 };

--- a/src/drawer/apis/getProductByProvider.ts
+++ b/src/drawer/apis/getProductByProvider.ts
@@ -1,0 +1,10 @@
+import { ProductResponses } from '../types/product.type';
+
+import { drawerClient } from './drawerClient';
+
+export const getProductByProvider = async (providerId: string): Promise<ProductResponses> => {
+  const { data } = await drawerClient.get(
+    `/v2/drawer?responseType=WEB&providerId=${providerId}&page=1`
+  );
+  return data;
+};

--- a/src/drawer/apis/getProductDetail.ts
+++ b/src/drawer/apis/getProductDetail.ts
@@ -1,0 +1,8 @@
+import { ProductDetailResponse } from '../types/product.type';
+
+import { drawerClient } from './drawerClient';
+
+export const getProductDetail = async (productNo: number): Promise<ProductDetailResponse> => {
+  const { data } = await drawerClient.get(`/v2/drawer/detail/${productNo}`);
+  return data;
+};

--- a/src/drawer/components/MoreProductSection/MoreProductSection.style.ts
+++ b/src/drawer/components/MoreProductSection/MoreProductSection.style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const StyledMoreProductSection = styled.div`
+  width: 18rem;
+  height: fit-content;
+  display: grid;
+  gap: 2rem;
+  padding: 0 0.5rem;
+  margin-left: 5.25rem;
+
+  /* Soomsil/Drawer/Web/title22 */
+  font-family: 'Spoqa Han Sans Neo';
+  font-size: 1.375rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 130%; /* 1.7875rem */
+  color: ${({ theme }) => theme.color.textPrimary};
+`;

--- a/src/drawer/components/MoreProductSection/MoreProductSection.tsx
+++ b/src/drawer/components/MoreProductSection/MoreProductSection.tsx
@@ -4,7 +4,7 @@ import { useGetProductByProvider } from '@/drawer/hooks/useGetProductByProvider'
 import { StyledMoreProductSection } from './MoreProductSection.style';
 
 export const MoreProductSection = ({ providerId }: { providerId: string }) => {
-  const { isSuccess, data } = useGetProductByProvider(providerId);
+  const { isSuccess, data } = useGetProductByProvider({ providerId });
 
   return (
     <>

--- a/src/drawer/components/MoreProductSection/MoreProductSection.tsx
+++ b/src/drawer/components/MoreProductSection/MoreProductSection.tsx
@@ -1,0 +1,29 @@
+import { SmallDrawerCard } from '@/drawer/components/DrawerCard/SmallDrawerCard';
+import { useGetProductByProvider } from '@/drawer/hooks/useGetProductByProvider';
+
+import { StyledMoreProductSection } from './MoreProductSection.style';
+
+export const MoreProductSection = ({ providerId }: { providerId: string }) => {
+  const { isSuccess, data } = useGetProductByProvider(providerId);
+
+  return (
+    <>
+      {isSuccess && data.length > 0 && (
+        <StyledMoreProductSection>
+          {providerId}의 서비스 더보기
+          {data.map(({ productTitle, count, productNo, mainImage }) => (
+            <SmallDrawerCard
+              key={productNo}
+              link={`/drawer/services/${productNo}`}
+              title={productTitle}
+              body={providerId}
+              bookmarkCount={count}
+              isBookmarked={true}
+              smallImgSrc={mainImage}
+            />
+          ))}
+        </StyledMoreProductSection>
+      )}
+    </>
+  );
+};

--- a/src/drawer/hooks/useGetProductByProvider.ts
+++ b/src/drawer/hooks/useGetProductByProvider.ts
@@ -8,5 +8,6 @@ export const useGetProductByProvider = (providerId: string) => {
     queryFn: () => {
       return getProductByProvider(providerId);
     },
+    select: (data) => data.productList,
   });
 };

--- a/src/drawer/hooks/useGetProductByProvider.ts
+++ b/src/drawer/hooks/useGetProductByProvider.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getProductByProvider } from '../apis/getProductByProvider';
+
+export const useGetProductByProvider = (providerId: string) => {
+  return useQuery({
+    queryKey: [providerId],
+    queryFn: () => {
+      return getProductByProvider(providerId);
+    },
+  });
+};

--- a/src/drawer/hooks/useGetProductByProvider.ts
+++ b/src/drawer/hooks/useGetProductByProvider.ts
@@ -2,11 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getProductByProvider } from '../apis/getProductByProvider';
 
-export const useGetProductByProvider = (providerId: string) => {
+export const useGetProductByProvider = ({
+  providerId,
+  page = 1,
+}: {
+  providerId: string;
+  page?: number;
+}) => {
   return useQuery({
     queryKey: [providerId],
     queryFn: () => {
-      return getProductByProvider(providerId);
+      return getProductByProvider({ providerId, page });
     },
     select: (data) => data.productList,
   });

--- a/src/drawer/hooks/useGetProductByProvider.ts
+++ b/src/drawer/hooks/useGetProductByProvider.ts
@@ -10,7 +10,7 @@ export const useGetProductByProvider = ({
   page?: number;
 }) => {
   return useQuery({
-    queryKey: [providerId],
+    queryKey: ['productByProvider', providerId],
     queryFn: () => {
       return getProductByProvider({ providerId, page });
     },

--- a/src/drawer/hooks/useGetProductDetail.ts
+++ b/src/drawer/hooks/useGetProductDetail.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getProductDetail } from '../apis/getProductDetail';
+
+export const useGetProductDetail = (productNo: number) => {
+  return useQuery({
+    queryKey: ['productDetail', productNo],
+    queryFn: () => {
+      return getProductDetail(productNo);
+    },
+  });
+};

--- a/src/drawer/hooks/useGetProductDetail.ts
+++ b/src/drawer/hooks/useGetProductDetail.ts
@@ -8,5 +8,6 @@ export const useGetProductDetail = (productNo: number) => {
     queryFn: () => {
       return getProductDetail(productNo);
     },
+    select: (data) => data.detail,
   });
 };

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.style.ts
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.style.ts
@@ -178,20 +178,3 @@ export const StyledDescription = styled.p`
   align-items: center;
   padding: 0 1rem;
 `;
-
-export const StyledMoreProductSection = styled.div`
-  width: 18rem;
-  height: fit-content;
-  display: grid;
-  gap: 2rem;
-  padding: 0 0.5rem;
-  margin-left: 5.25rem;
-
-  /* Soomsil/Drawer/Web/title22 */
-  font-family: 'Spoqa Han Sans Neo';
-  font-size: 1.375rem;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 130%; /* 1.7875rem */
-  color: ${({ theme }) => theme.color.textPrimary};
-`;

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -13,6 +13,7 @@ import { useTheme } from 'styled-components';
 import carouselLeftButton from '@/drawer/assets/carousel_left_button.svg';
 import carouselRightButton from '@/drawer/assets/carousel_right_button.svg';
 import { SmallDrawerCard } from '@/drawer/components/DrawerCard/SmallDrawerCard';
+import { useGetProductByProvider } from '@/drawer/hooks/useGetProductByProvider';
 import { useGetProductDetail } from '@/drawer/hooks/useGetProductDetail';
 
 import {
@@ -188,20 +189,34 @@ export const ServiceDetail = () => {
                 <StyledDescription>{data.detail.providerId}</StyledDescription>
               </StyledDescriptionPart>
             </StyledDescriptionSection>
-            <StyledMoreProductSection>
-              {data.detail.providerId}의 서비스 더보기
-              {Array.from({ length: 5 }).map(() => (
-                <SmallDrawerCard
-                  link={``}
-                  title={`TITLE`}
-                  body={data.detail.providerId}
-                  bookmarkCount={999}
-                  isBookmarked={true}
-                />
-              ))}
-            </StyledMoreProductSection>
+
+            <MoreProductSection providerId={data.detail.providerId} />
           </StyledLowerSection>
         </StyledServiceDetailContainer>
+      )}
+    </>
+  );
+};
+
+const MoreProductSection = ({ providerId }: { providerId: string }) => {
+  const { isSuccess, data } = useGetProductByProvider(providerId);
+
+  return (
+    <>
+      {isSuccess && data.productList.length > 0 && (
+        <StyledMoreProductSection>
+          {providerId}의 서비스 더보기
+          {data.productList.map(({ productTitle, count, productNo }) => (
+            <SmallDrawerCard
+              key={productNo}
+              link={`/drawer/services/${productNo}`}
+              title={productTitle}
+              body={providerId}
+              bookmarkCount={count}
+              isBookmarked={true}
+            />
+          ))}
+        </StyledMoreProductSection>
       )}
     </>
   );

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -206,7 +206,7 @@ const MoreProductSection = ({ providerId }: { providerId: string }) => {
       {isSuccess && data.productList.length > 0 && (
         <StyledMoreProductSection>
           {providerId}의 서비스 더보기
-          {data.productList.map(({ productTitle, count, productNo }) => (
+          {data.productList.map(({ productTitle, count, productNo, mainImage }) => (
             <SmallDrawerCard
               key={productNo}
               link={`/drawer/services/${productNo}`}
@@ -214,6 +214,7 @@ const MoreProductSection = ({ providerId }: { providerId: string }) => {
               body={providerId}
               bookmarkCount={count}
               isBookmarked={true}
+              smallImgSrc={mainImage}
             />
           ))}
         </StyledMoreProductSection>

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -74,13 +74,13 @@ export const ServiceDetail = () => {
     <>
       {isSuccess && (
         <StyledServiceDetailContainer>
-          <StyledBackgroundImageContainer $backgroundImage={data.detail.thumbnail}>
-            <StyledServiceTitleText>{data.detail.productTitle}</StyledServiceTitleText>
-            <StyledServiceDeveloperText>{data.detail.providerId}</StyledServiceDeveloperText>
+          <StyledBackgroundImageContainer $backgroundImage={data.thumbnail}>
+            <StyledServiceTitleText>{data.productTitle}</StyledServiceTitleText>
+            <StyledServiceDeveloperText>{data.providerId}</StyledServiceDeveloperText>
             <StyledServiceInfoContainer>
-              <StyledThumbnailImage src={data.detail.thumbnail} />
+              <StyledThumbnailImage src={data.thumbnail} />
               <StyledCategoryContainer>
-                <StyledCategoryText>{Category[data.detail.category]}</StyledCategoryText>
+                <StyledCategoryText>{Category[data.category]}</StyledCategoryText>
                 <StyledCategoryHintText>카테고리</StyledCategoryHintText>
               </StyledCategoryContainer>
             </StyledServiceInfoContainer>
@@ -92,13 +92,13 @@ export const ServiceDetail = () => {
                 variant="filled"
                 width="200px"
                 onClick={() => {
-                  const { appStoreUrl, googlePlayUrl, webpageUrl } = data.detail;
+                  const { appStoreUrl, googlePlayUrl, webpageUrl } = data;
                   window.open(appStoreUrl || googlePlayUrl || webpageUrl);
                 }}
               >
                 DOWNLOAD
               </BoxButton>
-              {data.detail.githubUrl && (
+              {data.githubUrl && (
                 /* TODO: 버튼 사이즈 반응형 적용 필요*/
                 <BoxButton
                   size="medium"
@@ -106,7 +106,7 @@ export const ServiceDetail = () => {
                   variant="tinted"
                   width="200px"
                   onClick={() => {
-                    window.open(data.detail.githubUrl);
+                    window.open(data.githubUrl);
                   }}
                 >
                   Github
@@ -137,7 +137,7 @@ export const ServiceDetail = () => {
                       size: '1.5rem',
                     }}
                   >
-                    {data.detail.isBookmarked ? <IcStarFilled /> : <IcStarLine />}
+                    {data.isBookmarked ? <IcStarFilled /> : <IcStarLine />}
                   </IconContext.Provider>
                 </button>
                 <StyledIconLabelText $color={'#FDD655'}>Recommend</StyledIconLabelText>
@@ -147,7 +147,7 @@ export const ServiceDetail = () => {
           <StyledLowerSection>
             <StyledDescriptionSection>
               <StyledCarousel ref={scrollRef}>
-                {data.detail.introductionImage.length > 1 && (
+                {data.introductionImage.length > 1 && (
                   <>
                     <StyledCarouselButton
                       $backgroundImage={carouselLeftButton}
@@ -165,14 +165,14 @@ export const ServiceDetail = () => {
                     />
                   </>
                 )}
-                {data.detail.introductionImage.map((imageSrc) => (
+                {data.introductionImage.map((imageSrc) => (
                   <StyledProductImage src={imageSrc} key={imageSrc} />
                 ))}
               </StyledCarousel>
               <StyledDescriptionPart>
                 <StyledSubtitle>{`추천`}</StyledSubtitle>
                 <StyledDescription>
-                  {data.detail.count}+
+                  {data.count}+
                   <IconContext.Provider value={{ size: '15px', color: '#FDD655' }}>
                     <IcStarFilled />
                   </IconContext.Provider>
@@ -181,16 +181,16 @@ export const ServiceDetail = () => {
 
               <StyledDescriptionPart>
                 <StyledSubtitle>{`서비스 소개`}</StyledSubtitle>
-                <StyledDescription>{data.detail.productContent}</StyledDescription>
+                <StyledDescription>{data.productContent}</StyledDescription>
               </StyledDescriptionPart>
 
               <StyledDescriptionPart>
                 <StyledSubtitle>{`저작권`}</StyledSubtitle>
-                <StyledDescription>{data.detail.providerId}</StyledDescription>
+                <StyledDescription>{data.providerId}</StyledDescription>
               </StyledDescriptionPart>
             </StyledDescriptionSection>
 
-            <MoreProductSection providerId={data.detail.providerId} />
+            <MoreProductSection providerId={data.providerId} />
           </StyledLowerSection>
         </StyledServiceDetailContainer>
       )}
@@ -203,10 +203,10 @@ const MoreProductSection = ({ providerId }: { providerId: string }) => {
 
   return (
     <>
-      {isSuccess && data.productList.length > 0 && (
+      {isSuccess && data.length > 0 && (
         <StyledMoreProductSection>
           {providerId}의 서비스 더보기
-          {data.productList.map(({ productTitle, count, productNo, mainImage }) => (
+          {data.map(({ productTitle, count, productNo, mainImage }) => (
             <SmallDrawerCard
               key={productNo}
               link={`/drawer/services/${productNo}`}

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -7,13 +7,13 @@ import {
   IconContext,
   IcStarFilled,
 } from '@yourssu/design-system-react';
-// import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 
-import backgroundImage from '@/assets/service_detail_background.png';
 import carouselLeftButton from '@/drawer/assets/carousel_left_button.svg';
 import carouselRightButton from '@/drawer/assets/carousel_right_button.svg';
 import { SmallDrawerCard } from '@/drawer/components/DrawerCard/SmallDrawerCard';
+import { useGetProductDetail } from '@/drawer/hooks/useGetProductDetail';
 
 import {
   StyledBackgroundImageContainer,
@@ -39,8 +39,20 @@ import {
   StyledLowerSection,
 } from './ServiceDetail.style';
 
+const Category = {
+  CAMPUS: '교내생활',
+  HOBBY: '취미',
+  HEALTH: '건강',
+  IT: 'IT',
+  KNOWLEDGE: '지식',
+  LIFESTYLE: '라이프스타일',
+  ETC: '기타',
+};
+
 export const ServiceDetail = () => {
-  // const { serviceId } = useParams();
+  const { serviceId } = useParams();
+  const { isSuccess, data } = useGetProductDetail(Number(serviceId));
+
   const theme = useTheme();
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -58,110 +70,139 @@ export const ServiceDetail = () => {
   };
 
   return (
-    <StyledServiceDetailContainer>
-      <StyledBackgroundImageContainer $backgroundImage={backgroundImage}>
-        <StyledServiceTitleText>TITLE</StyledServiceTitleText>
-        <StyledServiceDeveloperText>Developer</StyledServiceDeveloperText>
-        <StyledServiceInfoContainer>
-          <StyledThumbnailImage src={backgroundImage} />
-          <StyledCategoryContainer>
-            <StyledCategoryText>학교생활</StyledCategoryText>
-            <StyledCategoryHintText>카테고리</StyledCategoryHintText>
-          </StyledCategoryContainer>
-        </StyledServiceInfoContainer>
-        <StyledServiceActionContainer>
-          {/* TODO: 버튼 사이즈 반응형 적용 필요 */}
-          <BoxButton size="medium" rounding={8} variant="filled" width="200px">
-            DOWNLOAD
-          </BoxButton>
-          {/* TODO: 버튼 사이즈 반응형 적용 필요*/}
-          <BoxButton size="medium" rounding={8} variant="tinted" width="200px">
-            Github
-          </BoxButton>
-          <StyledIconButtonContainer>
-            <button>
-              {/* TODO: 추후 색상 변경 필요 */}
-              <IconContext.Provider
-                value={{
-                  color: theme.color.violetItemPrimary,
-                  size: '1.5rem',
+    <>
+      {isSuccess && (
+        <StyledServiceDetailContainer>
+          <StyledBackgroundImageContainer $backgroundImage={data.detail.thumbnail}>
+            <StyledServiceTitleText>{data.detail.productTitle}</StyledServiceTitleText>
+            <StyledServiceDeveloperText>{data.detail.providerId}</StyledServiceDeveloperText>
+            <StyledServiceInfoContainer>
+              <StyledThumbnailImage src={data.detail.thumbnail} />
+              <StyledCategoryContainer>
+                <StyledCategoryText>{Category[data.detail.category]}</StyledCategoryText>
+                <StyledCategoryHintText>카테고리</StyledCategoryHintText>
+              </StyledCategoryContainer>
+            </StyledServiceInfoContainer>
+            <StyledServiceActionContainer>
+              {/* TODO: 버튼 사이즈 반응형 적용 필요 */}
+              <BoxButton
+                size="medium"
+                rounding={8}
+                variant="filled"
+                width="200px"
+                onClick={() => {
+                  const { appStoreUrl, googlePlayUrl, webpageUrl } = data.detail;
+                  window.open(appStoreUrl || googlePlayUrl || webpageUrl);
                 }}
               >
-                <IcShareLine />
-              </IconContext.Provider>
-            </button>
-            <StyledIconLabelText $color={theme.color.violetItemPrimary}>SHARE</StyledIconLabelText>
-          </StyledIconButtonContainer>
-          <StyledIconButtonContainer>
-            <button>
-              {/* TODO: 추후 색상 변경 필요 */}
-              <IconContext.Provider
-                value={{
-                  color: '#FDD655',
-                  size: '1.5rem',
-                }}
-              >
-                <IcStarLine />
-              </IconContext.Provider>
-            </button>
-            <StyledIconLabelText $color={'#FDD655'}>Recommend</StyledIconLabelText>
-          </StyledIconButtonContainer>
-        </StyledServiceActionContainer>
-      </StyledBackgroundImageContainer>
-      <StyledLowerSection>
-        <StyledDescriptionSection>
-          <StyledCarousel ref={scrollRef}>
-            <StyledCarouselButton
-              $backgroundImage={carouselLeftButton}
-              $left={'-24px'}
-              type="button"
-              name="left"
-              onClick={handleCarouselClick}
-            />
-            <StyledCarouselButton
-              $backgroundImage={carouselRightButton}
-              $right={'-24px'}
-              type="button"
-              name="right"
-              onClick={handleCarouselClick}
-            />
-            {Array.from({ length: 3 }).map(() => (
-              <StyledProductImage src={backgroundImage} />
-            ))}
-          </StyledCarousel>
-          <StyledDescriptionPart>
-            <StyledSubtitle>{`추천`}</StyledSubtitle>
-            <StyledDescription>
-              {`999`}+
-              <IconContext.Provider value={{ size: '15px', color: '#FDD655' }}>
-                <IcStarFilled />
-              </IconContext.Provider>
-            </StyledDescription>
-          </StyledDescriptionPart>
+                DOWNLOAD
+              </BoxButton>
+              {data.detail.githubUrl && (
+                /* TODO: 버튼 사이즈 반응형 적용 필요*/
+                <BoxButton
+                  size="medium"
+                  rounding={8}
+                  variant="tinted"
+                  width="200px"
+                  onClick={() => {
+                    window.open(data.detail.githubUrl);
+                  }}
+                >
+                  Github
+                </BoxButton>
+              )}
+              <StyledIconButtonContainer>
+                <button>
+                  {/* TODO: 추후 색상 변경 필요 */}
+                  <IconContext.Provider
+                    value={{
+                      color: theme.color.violetItemPrimary,
+                      size: '1.5rem',
+                    }}
+                  >
+                    <IcShareLine />
+                  </IconContext.Provider>
+                </button>
+                <StyledIconLabelText $color={theme.color.violetItemPrimary}>
+                  SHARE
+                </StyledIconLabelText>
+              </StyledIconButtonContainer>
+              <StyledIconButtonContainer>
+                <button>
+                  {/* TODO: 추후 색상 변경 필요 */}
+                  <IconContext.Provider
+                    value={{
+                      color: '#FDD655',
+                      size: '1.5rem',
+                    }}
+                  >
+                    {data.detail.isBookmarked ? <IcStarFilled /> : <IcStarLine />}
+                  </IconContext.Provider>
+                </button>
+                <StyledIconLabelText $color={'#FDD655'}>Recommend</StyledIconLabelText>
+              </StyledIconButtonContainer>
+            </StyledServiceActionContainer>
+          </StyledBackgroundImageContainer>
+          <StyledLowerSection>
+            <StyledDescriptionSection>
+              <StyledCarousel ref={scrollRef}>
+                {data.detail.introductionImage.length > 1 && (
+                  <>
+                    <StyledCarouselButton
+                      $backgroundImage={carouselLeftButton}
+                      $left={'-24px'}
+                      type="button"
+                      name="left"
+                      onClick={handleCarouselClick}
+                    />
+                    <StyledCarouselButton
+                      $backgroundImage={carouselRightButton}
+                      $right={'-24px'}
+                      type="button"
+                      name="right"
+                      onClick={handleCarouselClick}
+                    />
+                  </>
+                )}
+                {data.detail.introductionImage.map((imageSrc) => (
+                  <StyledProductImage src={imageSrc} key={imageSrc} />
+                ))}
+              </StyledCarousel>
+              <StyledDescriptionPart>
+                <StyledSubtitle>{`추천`}</StyledSubtitle>
+                <StyledDescription>
+                  {data.detail.count}+
+                  <IconContext.Provider value={{ size: '15px', color: '#FDD655' }}>
+                    <IcStarFilled />
+                  </IconContext.Provider>
+                </StyledDescription>
+              </StyledDescriptionPart>
 
-          <StyledDescriptionPart>
-            <StyledSubtitle>{`서비스 소개`}</StyledSubtitle>
-            <StyledDescription>{`service`}</StyledDescription>
-          </StyledDescriptionPart>
+              <StyledDescriptionPart>
+                <StyledSubtitle>{`서비스 소개`}</StyledSubtitle>
+                <StyledDescription>{data.detail.productContent}</StyledDescription>
+              </StyledDescriptionPart>
 
-          <StyledDescriptionPart>
-            <StyledSubtitle>{`저작권`}</StyledSubtitle>
-            <StyledDescription>{`Yourssu`}</StyledDescription>
-          </StyledDescriptionPart>
-        </StyledDescriptionSection>
-        <StyledMoreProductSection>
-          {`제작자`}의 서비스 더보기
-          {Array.from({ length: 5 }).map(() => (
-            <SmallDrawerCard
-              link={``}
-              title={`TITLE`}
-              body={`제작자`}
-              bookmarkCount={999}
-              isBookmarked={true}
-            />
-          ))}
-        </StyledMoreProductSection>
-      </StyledLowerSection>
-    </StyledServiceDetailContainer>
+              <StyledDescriptionPart>
+                <StyledSubtitle>{`저작권`}</StyledSubtitle>
+                <StyledDescription>{data.detail.providerId}</StyledDescription>
+              </StyledDescriptionPart>
+            </StyledDescriptionSection>
+            <StyledMoreProductSection>
+              {data.detail.providerId}의 서비스 더보기
+              {Array.from({ length: 5 }).map(() => (
+                <SmallDrawerCard
+                  link={``}
+                  title={`TITLE`}
+                  body={data.detail.providerId}
+                  bookmarkCount={999}
+                  isBookmarked={true}
+                />
+              ))}
+            </StyledMoreProductSection>
+          </StyledLowerSection>
+        </StyledServiceDetailContainer>
+      )}
+    </>
   );
 };

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -112,33 +112,31 @@ export const ServiceDetail = () => {
               )}
               <StyledIconButtonContainer>
                 <button>
-                  {/* TODO: 추후 색상 변경 필요 */}
                   <IconContext.Provider
                     value={{
-                      color: theme.color.violetItemPrimary,
+                      color: theme.color.pointViolet,
                       size: '1.5rem',
                     }}
                   >
                     <IcShareLine />
                   </IconContext.Provider>
                 </button>
-                <StyledIconLabelText $color={theme.color.violetItemPrimary}>
-                  SHARE
-                </StyledIconLabelText>
+                <StyledIconLabelText $color={theme.color.pointViolet}>SHARE</StyledIconLabelText>
               </StyledIconButtonContainer>
               <StyledIconButtonContainer>
                 <button>
-                  {/* TODO: 추후 색상 변경 필요 */}
                   <IconContext.Provider
                     value={{
-                      color: '#FDD655',
+                      color: theme.color.pointYellow,
                       size: '1.5rem',
                     }}
                   >
                     {data.isBookmarked ? <IcStarFilled /> : <IcStarLine />}
                   </IconContext.Provider>
                 </button>
-                <StyledIconLabelText $color={'#FDD655'}>Recommend</StyledIconLabelText>
+                <StyledIconLabelText $color={theme.color.pointYellow}>
+                  Recommend
+                </StyledIconLabelText>
               </StyledIconButtonContainer>
             </StyledServiceActionContainer>
           </StyledBackgroundImageContainer>

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -12,8 +12,7 @@ import { useTheme } from 'styled-components';
 
 import carouselLeftButton from '@/drawer/assets/carousel_left_button.svg';
 import carouselRightButton from '@/drawer/assets/carousel_right_button.svg';
-import { SmallDrawerCard } from '@/drawer/components/DrawerCard/SmallDrawerCard';
-import { useGetProductByProvider } from '@/drawer/hooks/useGetProductByProvider';
+import { MoreProductSection } from '@/drawer/components/MoreProductSection/MoreProductSection';
 import { useGetProductDetail } from '@/drawer/hooks/useGetProductDetail';
 
 import {
@@ -32,7 +31,6 @@ import {
   StyledDescription,
   StyledDescriptionPart,
   StyledDescriptionSection,
-  StyledMoreProductSection,
   StyledProductImage,
   StyledCarousel,
   StyledSubtitle,
@@ -193,31 +191,6 @@ export const ServiceDetail = () => {
             <MoreProductSection providerId={data.providerId} />
           </StyledLowerSection>
         </StyledServiceDetailContainer>
-      )}
-    </>
-  );
-};
-
-const MoreProductSection = ({ providerId }: { providerId: string }) => {
-  const { isSuccess, data } = useGetProductByProvider(providerId);
-
-  return (
-    <>
-      {isSuccess && data.length > 0 && (
-        <StyledMoreProductSection>
-          {providerId}의 서비스 더보기
-          {data.map(({ productTitle, count, productNo, mainImage }) => (
-            <SmallDrawerCard
-              key={productNo}
-              link={`/drawer/services/${productNo}`}
-              title={productTitle}
-              body={providerId}
-              bookmarkCount={count}
-              isBookmarked={true}
-              smallImgSrc={mainImage}
-            />
-          ))}
-        </StyledMoreProductSection>
       )}
     </>
   );

--- a/src/drawer/types/product.type.ts
+++ b/src/drawer/types/product.type.ts
@@ -17,6 +17,7 @@ export interface ProductDetailResult {
   productTitle: string;
   providerId: string;
   thumbnail: string;
+  webpageUrl?: string;
 }
 
 export interface ProductDetailResponse {

--- a/src/drawer/types/product.type.ts
+++ b/src/drawer/types/product.type.ts
@@ -1,0 +1,24 @@
+export interface ProductDetailResult {
+  actionContent?: string;
+  actionType: 'BROWSER' | 'DEEPLINK' | 'WEB_VIEW';
+  appStoreUrl?: string;
+  category: 'CAMPUS' | 'ETC' | 'HEALTH' | 'HOBBY' | 'IT' | 'KNOWLEDGE' | 'LIFESTYLE';
+  count: number;
+  expireDay: number;
+  githubUrl?: string;
+  googlePlayUrl?: string;
+  introductionImage: string[];
+  isAd: boolean;
+  isBookmarked: boolean;
+  productBookmarkKey?: number;
+  productContent: string;
+  productNo: number;
+  productSubTitle: string;
+  productTitle: string;
+  providerId: string;
+  thumbnail: string;
+}
+
+export interface ProductDetailResponse {
+  detail: ProductDetailResult;
+}

--- a/src/drawer/types/product.type.ts
+++ b/src/drawer/types/product.type.ts
@@ -20,6 +20,26 @@ export interface ProductDetailResult {
   webpageUrl?: string;
 }
 
+export interface ProductResult {
+  actionContent?: string;
+  actionType: 'BROWSER' | 'DEEPLINK' | 'WEB_VIEW';
+  category: 'CAMPUS' | 'ETC' | 'HEALTH' | 'HOBBY' | 'IT' | 'KNOWLEDGE' | 'LIFESTYLE';
+  count: number;
+  expireDay: number;
+  introductionImage: string[];
+  isAd: boolean;
+  mainImage: string;
+  productBookmarkKey?: number;
+  productNo: number;
+  productSubTitle: string;
+  productTitle: string;
+  status: 'ACTIVE' | 'INACTIVE';
+}
+
 export interface ProductDetailResponse {
   detail: ProductDetailResult;
+}
+
+export interface ProductResponses {
+  productList: ProductResult[];
 }

--- a/src/drawer/types/product.type.ts
+++ b/src/drawer/types/product.type.ts
@@ -1,8 +1,12 @@
+type ActionType = 'BROWSER' | 'DEEPLINK' | 'WEB_VIEW';
+
+type CategoryType = 'CAMPUS' | 'ETC' | 'HEALTH' | 'HOBBY' | 'IT' | 'KNOWLEDGE' | 'LIFESTYLE';
+
 export interface ProductDetailResult {
   actionContent?: string;
-  actionType: 'BROWSER' | 'DEEPLINK' | 'WEB_VIEW';
+  actionType: ActionType;
   appStoreUrl?: string;
-  category: 'CAMPUS' | 'ETC' | 'HEALTH' | 'HOBBY' | 'IT' | 'KNOWLEDGE' | 'LIFESTYLE';
+  category: CategoryType;
   count: number;
   expireDay: number;
   githubUrl?: string;
@@ -22,8 +26,8 @@ export interface ProductDetailResult {
 
 export interface ProductResult {
   actionContent?: string;
-  actionType: 'BROWSER' | 'DEEPLINK' | 'WEB_VIEW';
-  category: 'CAMPUS' | 'ETC' | 'HEALTH' | 'HOBBY' | 'IT' | 'KNOWLEDGE' | 'LIFESTYLE';
+  actionType: ActionType;
+  category: CategoryType;
   count: number;
   expireDay: number;
   introductionImage: string[];


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #107 

![detail](https://github.com/yourssu/Soomsil-Web/assets/87255462/25df2fbb-ead2-4252-9fb4-09d8b2935d18)

![other_product](https://github.com/yourssu/Soomsil-Web/assets/87255462/d097152c-a423-4982-be53-b75474e690b2)

### 기존 코드에 영향을 미치지 않는 변경사항

- `src/drawer/apis/getProductByProvider.ts` : 제작자의 서비스를 가져오는 api

- `src/drawer/apis/getProductDetail.ts` : 프로덕트 1개의 정보를 가져오는 api

- `제작자의 서비스 더보기` 내용을 `ServiceDetail` 내 별도의 컴포넌트로 분리했습니다.

## 2️⃣ 알아두시면 좋아요!
- 버튼 눌렀을 때 링크는 모두 새 창에서 열립니다! 거기까지 녹화가 안되었지만... 새 창으로 열려요...............

- 더보기쪽에 제작자의 서비스가 5개 이상인 경우 **제작자의 프로덕트만 모아보는 페이지로 넘어가는 화살표**가 생겨야 하는데,
페이지 자체가 없다보니 차라리 이슈 하나 파서 진행하는 게 맞다고 생각해서 제외시켰습니다 까먹은 거 아닙니다

- 상세 페이지도 에러 처리가 안 되어있는 상황인데, 에러 처리 방향에 대한 가닥이 잡히면 반영하겠습니다..🤔

## 3️⃣ 추후 작업
- PR 리뷰 기반 수정

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
