### PR TITLE
chore: lint-staged {ts, tsx}만 검사하도록 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "lint-staged": {
-    "src/**": [
+    "src/**/*.{js, jsx, ts, tsx}": [
       "eslint --fix",
       "prettier --write"
     ]


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #141 

### 버그 픽스
lint-staged에서 소스파일이 아닌 이외의 것들에(이미지와 같은 바이너리 파일) 대한 lint 검사를 하지 않도록 변경

## 2️⃣ 알아두시면 좋아요!
src 하위의 {ts, tsx} 파일에 대한 검사만 실시하도록 변경했습니다.

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
