### PR TITLE
fix: drawerClient -> soomsilClient 로 변경

### DIFF
--- a/src/drawer/apis/getBookMarked.ts
+++ b/src/drawer/apis/getBookMarked.ts
@@ -1,10 +1,10 @@
+import { soomsilClient } from '@/apis';
+
 import { RankingRequestParams } from '../types/RankingRequestParams.type';
 import { ProductResponses } from '../types/product.type';
 
-import { drawerClient } from './drawerClient';
-
 export const getBookmarked = async ({ responseType, page }: RankingRequestParams) => {
-  const response = await drawerClient.get<ProductResponses>('/v2/drawer/my-bookmarked', {
+  const response = await soomsilClient.get<ProductResponses>('/v2/drawer/my-bookmarked', {
     params: {
       responseType,
       page,

--- a/src/drawer/apis/getMyProduct.ts
+++ b/src/drawer/apis/getMyProduct.ts
@@ -1,10 +1,10 @@
+import { soomsilClient } from '@/apis';
+
 import { RankingRequestParams } from '../types/RankingRequestParams.type';
 import { ProductResponses } from '../types/product.type';
 
-import { drawerClient } from './drawerClient';
-
 export const getMyProduct = async ({ responseType, page }: RankingRequestParams) => {
-  const response = await drawerClient.get<ProductResponses>('/v2/drawer/my-registered', {
+  const response = await soomsilClient.get<ProductResponses>('/v2/drawer/my-registered', {
     params: {
       responseType,
       page,


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

현재 develop 브랜치에서 pull 하면 발생하는 이슈를 해결했습니다. (아래 참고)

- resolved #144 

해당 [PR](https://github.com/yourssu/Soomsil-Web/pull/129) 에서 발견하지 못한 이슈 같습니다!

drawerClient가 soomsilClient로 변경되면서 
`getBookMarked.ts`와 `getMyProduct.ts` 두 파일에 수정사항이 적용되지 않았습니다.


## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
