### PR TITLE
Feat: 로그인 페이지 코드 리팩토링

### DIFF
--- a/src/constants/email.constant.ts
+++ b/src/constants/email.constant.ts
@@ -1,0 +1,1 @@
+export const EMAIL_DOMAIN = '@soongsil.ac.kr';

--- a/src/home/components/LoginInput/LoginInput.style.ts
+++ b/src/home/components/LoginInput/LoginInput.style.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const StyledLoginInputTitle = styled.div`
+  ${({ theme }) => theme.typo.subtitle6};
+  padding-left: 4px;
+  padding-bottom: 3px;
+`;
+
+export const StyledLoginInputHelperLabel = styled.div`
+  ${({ theme }) => theme.typo.caption1};
+  margin-top: 8px;
+  white-space: pre-line;
+  color: #ff5252; // theme에서 못 찾겠네요...
+`;

--- a/src/home/components/LoginInput/LoginInput.style.ts
+++ b/src/home/components/LoginInput/LoginInput.style.ts
@@ -10,5 +10,5 @@ export const StyledLoginInputHelperLabel = styled.div`
   ${({ theme }) => theme.typo.caption1};
   margin-top: 8px;
   white-space: pre-line;
-  color: #ff5252; // theme에서 못 찾겠네요...
+  color: ${({ theme }) => theme.color.textWarned};
 `;

--- a/src/home/components/LoginInput/LoginInput.tsx
+++ b/src/home/components/LoginInput/LoginInput.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+
+import { IcEyeclosedLine, IcEyeopenLine, SimpleTextField } from '@yourssu/design-system-react';
+
+import { StyledSignupInputSuffix } from '../SignupContents/SignupForm/SignupInput/SignupInput.style';
+
+import { StyledLoginInputHelperLabel, StyledLoginInputTitle } from './LoginInput.style';
+
+interface LoginInputProps {
+  title: string;
+  helperLabel: React.ReactNode;
+  placeholder: string;
+  isNegative?: boolean;
+  hiddenField?: boolean;
+
+  onChange: (value: string) => void;
+}
+
+interface HiddenFieldEyeButtonProps {
+  isFieldHidden: boolean;
+  onClick: () => void;
+}
+
+const HiddenFieldEyeButton = ({ isFieldHidden, onClick }: HiddenFieldEyeButtonProps) => {
+  return (
+    <button className="suffix-icon" onClick={onClick}>
+      {isFieldHidden ? <IcEyeclosedLine /> : <IcEyeopenLine />}
+    </button>
+  );
+};
+
+export const LoginInput = ({
+  title,
+  helperLabel,
+  placeholder,
+  isNegative = false,
+  hiddenField = false,
+  onChange,
+}: LoginInputProps) => {
+  const [value, setValue] = useState('');
+  const [isFieldHidden, setIsFieldHidden] = useState(true);
+
+  const fieldType = hiddenField && isFieldHidden ? 'password' : 'text';
+  const isHiddenFieldSuffixVisible = hiddenField && value.length > 0;
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    setValue(inputValue);
+    onChange(inputValue);
+  };
+
+  const toggleHiddenField = () => {
+    if (!hiddenField) return;
+    setIsFieldHidden((prev) => !prev);
+  };
+
+  const getSuffixProps = () => {
+    if (!hiddenField) {
+      return {
+        onClickClearButton: () => setValue(''),
+      };
+    }
+
+    return {
+      suffix: isHiddenFieldSuffixVisible && (
+        <HiddenFieldEyeButton isFieldHidden={isFieldHidden} onClick={toggleHiddenField} />
+      ),
+    };
+  };
+
+  return (
+    <div>
+      <StyledLoginInputTitle>{title}</StyledLoginInputTitle>
+      <StyledSignupInputSuffix>
+        <SimpleTextField
+          value={value}
+          type={fieldType}
+          onChange={onInputChange}
+          placeholder={placeholder}
+          isNegative={isNegative}
+          {...getSuffixProps()}
+        />
+        <StyledLoginInputHelperLabel>{isNegative ? helperLabel : ''}</StyledLoginInputHelperLabel>
+      </StyledSignupInputSuffix>
+    </div>
+  );
+};

--- a/src/home/components/SignupContents/EmailForm/EmailForm.tsx
+++ b/src/home/components/SignupContents/EmailForm/EmailForm.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 
 import { BoxButton, PlainButton, SimpleTextField } from '@yourssu/design-system-react';
 
+import { EMAIL_DOMAIN } from '@/constants/email.constant';
+import { useFullEmail } from '@/hooks/useFullEmail';
+
 import {
   StyledSignupButtonText,
   StyledSignupContentContainer,
@@ -20,19 +23,16 @@ interface EmailFormProps {
   onConfirm: (email: string) => void;
 }
 
-const EMAIL_DOMAIN = '@soongsil.ac.kr';
-
 export const EmailForm = ({ onConfirm }: EmailFormProps) => {
   const [email, setEmail] = useState('');
+  const getFullEmail = useFullEmail(email);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
   };
 
   const onEmailSubmit = () => {
-    let fullEmail = email;
-    if (!email.endsWith(EMAIL_DOMAIN)) fullEmail += EMAIL_DOMAIN;
-    onConfirm(fullEmail);
+    onConfirm(getFullEmail());
   };
 
   return (

--- a/src/home/components/SignupFrame/SignupFrame.style.ts
+++ b/src/home/components/SignupFrame/SignupFrame.style.ts
@@ -12,6 +12,7 @@ export const StyledSignupFrame = styled.div`
 
 export const StyledSignupFrameLogo = styled.img`
   width: 180px;
+  cursor: pointer;
 `;
 
 export const StyledSignupFrameContentContainer = styled.div`

--- a/src/home/components/SignupFrame/SignupFrame.tsx
+++ b/src/home/components/SignupFrame/SignupFrame.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import Logo from '@/assets/soomsil_v2_logo.svg';
 
 import {
@@ -11,9 +13,11 @@ interface SignupFrameProps {
 }
 
 export const SignupFrame = ({ children }: SignupFrameProps) => {
+  const navigate = useNavigate();
+
   return (
     <StyledSignupFrame>
-      <StyledSignupFrameLogo src={Logo} />
+      <StyledSignupFrameLogo src={Logo} onClick={() => navigate('/')} />
       <StyledSignupFrameContentContainer>{children}</StyledSignupFrameContentContainer>
     </StyledSignupFrame>
   );

--- a/src/home/pages/Login/Login.style.ts
+++ b/src/home/pages/Login/Login.style.ts
@@ -1,166 +1,25 @@
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const StyledContainer = styled.article`
+export const StyledLoginContainer = styled.div`
+  width: 100%;
+
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  gap: 24px;
+`;
+
+export const StyledBottomButtonContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 2.25rem;
 `;
 
-export const StyledLogo = styled.img`
-  width: 11.25rem;
-  height: 2.375rem;
-  cursor: pointer;
-`;
-
-export const StyledLoginContainer = styled.section`
-  border-radius: 1rem;
-  border: 1px solid ${({ theme }) => theme.color.borderNormal};
-  justify-content: center;
-  display: flex;
-  flex-direction: column;
-  padding: 1.38rem 1.5rem;
-`;
-
-export const StyledTitle = styled.div`
-  color: ${({ theme }) => theme.color.textSecondary};
-  ${({ theme }) => theme.typo.title2};
-  text-align: center;
-`;
-
-export const StyledLabel = styled.div`
-  color: ${({ theme }) => theme.color.textSecondary};
-  ${({ theme }) => theme.typo.subtitle3};
-`;
-
-export const StyledInputContainer = styled.article`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding-top: 1.5rem;
-`;
-export const StyledButtonLabel = styled(Link)`
-  color: ${({ theme }) => theme.color.textTertiary};
+export const StyledBottomButtonWrapper = styled.div`
   ${({ theme }) => theme.typo.button3};
 `;
-export const StyledButtonDivider = styled.div`
-  color: ${({ theme }) => theme.color.textTertiary};
-  /* wd web/Body3 R */
-  font-family: Pretendard;
-  font-size: 0.875rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1.375rem;
-`;
-export const StyledInputRowContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-`;
 
-export const StyledInput = styled.input`
-  width: 100%;
-  background-color: ${({ theme }) => theme.color.inputFieldElevated};
-  ${({ theme }) => theme.typo.body1};
+export const StyledButtonButtonSeparator = styled.div`
   color: ${({ theme }) => theme.color.textTertiary};
-  height: 3rem;
-  border-top-left-radius: 0.5rem;
-  border-bottom-left-radius: 0.5rem;
-  padding: 0.75rem 1rem;
-  &:-webkit-autofill,
-  &:-webkit-autofill:hover,
-  &:-webkit-autofill:focus,
-  &:-webkit-autofill:active {
-    -webkit-box-shadow: 0 0 0px 1000px ${({ theme }) => theme.color.inputFieldElevated} inset;
-    box-shadow: 0 0 0px 1000px ${({ theme }) => theme.color.inputFieldElevated} inset;
-    -webkit-text-fill-color: ${({ theme }) => theme.color.textTertiary} !important;
-  }
-`;
-export const StyledFailedInput = styled.input`
-  width: 100%;
-  border: 1px solid #ff5252;
-  background-color: ${({ theme }) => theme.color.inputFieldElevated};
-  ${({ theme }) => theme.typo.body1};
-  color: ${({ theme }) => theme.color.textTertiary};
-  height: 3rem;
-  border-radius: 0.5rem;
-  padding: 0.75rem 1rem;
-  &:-webkit-autofill,
-  &:-webkit-autofill:hover,
-  &:-webkit-autofill:focus,
-  &:-webkit-autofill:active {
-    -webkit-box-shadow: 0 0 0px 1000px ${({ theme }) => theme.color.inputFieldElevated} inset;
-    box-shadow: 0 0 0px 1000px ${({ theme }) => theme.color.inputFieldElevated} inset;
-    -webkit-text-fill-color: ${({ theme }) => theme.color.textTertiary} !important;
-  }
-`;
-export const StyledFailedLeftInput = styled.input`
-  width: 100%;
-  border-left: 1px solid #ff5252;
-  border-top: 1px solid #ff5252;
-  border-bottom: 1px solid #ff5252;
-  background-color: ${({ theme }) => theme.color.inputFieldElevated};
-  ${({ theme }) => theme.typo.body1};
-  color: ${({ theme }) => theme.color.textTertiary};
-  height: 3rem;
-  border-radius: 0.5rem 0 0 0.5rem;
-  padding: 0.75rem 1rem;
-
-  &:-webkit-autofill,
-  &:-webkit-autofill:hover,
-  &:-webkit-autofill:focus,
-  &:-webkit-autofill:active {
-    -webkit-box-shadow: 0 0 0px 1000px ${({ theme }) => theme.color.inputFieldElevated} inset;
-    box-shadow: 0 0 0px 1000px ${({ theme }) => theme.color.inputFieldElevated} inset;
-    -webkit-text-fill-color: ${({ theme }) => theme.color.textTertiary} !important;
-  }
-`;
-export const StyledFailedInputSuffix = styled.div`
-  background-color: ${({ theme }) => theme.color.inputFieldElevated};
-  border: 1px solid #ff5252;
-  ${({ theme }) => theme.typo.body1};
-  color: ${({ theme }) => theme.color.textTertiary};
-  height: 3rem;
-  border-radius: 0 0.5rem 0.5rem 0;
-  padding: 0.75rem 1rem;
-`;
-export const StyledFailedRightInputSuffix = styled.div`
-  background-color: ${({ theme }) => theme.color.inputFieldElevated};
-  border-right: 1px solid #ff5252;
-  border-top: 1px solid #ff5252;
-  border-bottom: 1px solid #ff5252;
-  ${({ theme }) => theme.typo.body1};
-  color: ${({ theme }) => theme.color.textTertiary};
-  height: 3rem;
-  border-radius: 0 0.5rem 0.5rem 0;
-  padding: 0.75rem 1rem;
-`;
-export const StyledInputSuffix = styled.div`
-  background-color: ${({ theme }) => theme.color.inputFieldElevated};
-  ${({ theme }) => theme.typo.body1};
-  color: ${({ theme }) => theme.color.textTertiary};
-  height: 3rem;
-  border-radius: 0 0.5rem 0.5rem 0;
-  padding: 0.75rem 1rem;
-`;
-
-export const StyledBottomContainer = styled.section`
-  display: flex;
-  flex-direction: row;
-  padding: 0 2.25rem;
-  gap: 2.25rem;
-`;
-export const StyledErrorMessageContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  ${({ theme }) => theme.typo.caption1};
-  color: #ff5252;
-  padding-top: 0.5rem;
-`;
-export const StyledLoginButtonContainer = styled.section`
-  padding-top: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 1.5rem;
 `;

--- a/src/home/pages/Login/Login.tsx
+++ b/src/home/pages/Login/Login.tsx
@@ -10,6 +10,7 @@ import { StyledSignupContentTitle } from '@/home/components/SignupContents/Signu
 import { SignupFrame } from '@/home/components/SignupFrame/SignupFrame';
 import { useGetUserData } from '@/home/hooks/useGetUserData';
 import { useFullEmail } from '@/hooks/useFullEmail';
+import { useRedirectLoggedInEffect } from '@/hooks/useRedirectLoggedInEffect';
 import { api } from '@/service/TokenService';
 
 import {
@@ -50,6 +51,9 @@ export const Login = () => {
       return;
     }
   };
+
+  // 로그인 상태에서는 홈으로 리다이렉트
+  useRedirectLoggedInEffect();
 
   return (
     <SignupFrame>

--- a/src/hooks/useFullEmail.ts
+++ b/src/hooks/useFullEmail.ts
@@ -1,0 +1,10 @@
+import { EMAIL_DOMAIN } from '@/constants/email.constant';
+
+export const useFullEmail = (email: string) => {
+  const getFullEmail = () => {
+    if (!email.endsWith(EMAIL_DOMAIN)) return email + EMAIL_DOMAIN;
+    return email;
+  };
+
+  return getFullEmail;
+};

--- a/src/hooks/useRedirectLoggedInEffect.ts
+++ b/src/hooks/useRedirectLoggedInEffect.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { useIsLoggedIn } from './useIsLoggedIn';
+
+export const useRedirectLoggedInEffect = () => {
+  const navigate = useNavigate();
+  const isLoggedIn = useIsLoggedIn();
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    navigate('/');
+  }, [isLoggedIn, navigate]);
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

로그인 페이지를 더 간결하게 리팩토링했습니다.

- resolved #149 
- resolved #137 
=> 로그인 페이지를 리팩토링하면 #137의 문제도 해결되서... 둘다 한꺼번에 진행했습니다.

### 기존 코드에 영향을 미치지 않는 변경사항

1. `src/constants/email.constant.ts` 에 이메일 도메인 관련 상수 추가했습니다.
2. 로그인 페이지의 로고 클릭 시 홈으로 갑니다.

### 기존 코드에 영향을 미치는 변경사항

1. 회원가입 페이지의 로고 역시 클릭시 홈으로 가도록 변경했는데, 잘못하면 confilct 날 수 있으니 충돌나면 해결하겠습니다.
2. 로그인 페이지 코드가 아예 싹 바뀌어서 merge시 충돌나는 부분은 제가 빠르게 수정하겠습니다.


### 버그 픽스

#137 문제가 해결되었습니다.


## 2️⃣ 알아두시면 좋아요!

아직 로그인 페이지의 '학교 메일 찾기' 기능과 '비밀번호 찾기' 에 대한 route가 구현되지 않아보여,
이 부분은 제외하고 구현하였습니다.

구현되는 대로 저 또한 추가하겠습니당

## 3️⃣ 추후 작업

- 학교 메일 찾기 및 비밀번호 찾기 navigate 기능 추가

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
