### PR TITLE
Fix: ServiceDetail, Fallback 컴포넌트에서 발생하는 타입 에러 수정

### DIFF
--- a/src/components/Fallback/Fallback.tsx
+++ b/src/components/Fallback/Fallback.tsx
@@ -16,7 +16,10 @@ import { FALLBACK_TEXT } from '@/constants/fallback.constant';
 const getFallbackContent = (status: number): FallbackContent => {
   if (status >= 500) return FALLBACK_TEXT['SERVER'];
   if (status >= 400) return FALLBACK_TEXT['CLIENT'];
-  return { boldText: '' };
+  return {
+    boldText: '',
+    buttonText: '',
+  };
 };
 
 export const Fallback = ({ error, resetErrorBoundary }: FallbackProps) => {

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -208,7 +208,7 @@ export const ServiceDetail = () => {
           </StyledDescriptionPart>
         </StyledDescriptionSection>
 
-        <MoreProductSection providerId={product.providerId} />
+        <MoreProductSection providerName={product.providerName} providerId={product.providerId} />
       </StyledLowerSection>
     </StyledServiceDetailContainer>
   );

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -90,7 +90,7 @@ export const ServiceDetail = () => {
     <StyledServiceDetailContainer>
       <StyledBackgroundImageContainer $backgroundImage={product.thumbnail}>
         <StyledServiceTitleText>{product.productTitle}</StyledServiceTitleText>
-        <StyledServiceDeveloperText>{product.providerId}</StyledServiceDeveloperText>
+        <StyledServiceDeveloperText>{product.providerName}</StyledServiceDeveloperText>
         <StyledServiceInfoContainer>
           <StyledThumbnailImage src={product.thumbnail} />
           <StyledCategoryContainer>
@@ -204,7 +204,7 @@ export const ServiceDetail = () => {
 
           <StyledDescriptionPart>
             <StyledSubtitle>{`저작권`}</StyledSubtitle>
-            <StyledDescription>{product.providerId}</StyledDescription>
+            <StyledDescription>{product.providerName}</StyledDescription>
           </StyledDescriptionPart>
         </StyledDescriptionSection>
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #165

### 버그 픽스

- 누락된 props 추가

  - ServiceDetail에서 MoreProductSection을 사용할 때 providerName가 빠져있었음
  - providerId -> providerName으로 변경했던 부분 중 일부가 다시 providerId로 돌아가있어서 그것도 끼워넣음

- 누락된 field 추가

  - getFallbackContent()의 마지막 return문에서 `FallbackContent`의 필수 속성인 buttonText가 빠져있었음

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
