### PR TITLE
refactor: ProviderProductResponses 구조 변경 및 관련 코드 리팩토링

### DIFF
--- a/src/drawer/apis/getProductByProvider.ts
+++ b/src/drawer/apis/getProductByProvider.ts
@@ -1,11 +1,11 @@
 import { soomsilClient } from '@/apis';
-import { GetProductByProviderProps, ProductResponses } from '@/drawer/types/product.type';
+import { GetProductByProviderProps, ProviderProductResponses } from '@/drawer/types/product.type';
 
 export const getProductByProvider = async ({
   providerId,
   page = 0,
   category = '',
-}: GetProductByProviderProps): Promise<ProductResponses> => {
+}: GetProductByProviderProps): Promise<ProviderProductResponses> => {
   const { data } = await soomsilClient.get('/v2/drawer', {
     params: {
       responseType: 'WEB',
@@ -14,5 +14,5 @@ export const getProductByProvider = async ({
       category,
     },
   });
-  return data;
+  return data.result;
 };

--- a/src/drawer/components/MoreProductSection/MoreProductSection.tsx
+++ b/src/drawer/components/MoreProductSection/MoreProductSection.tsx
@@ -14,10 +14,10 @@ export const MoreProductSection = ({
 
   return (
     <>
-      {isSuccess && data.length > 0 && (
+      {isSuccess && data && (
         <StyledMoreProductSection>
           {providerName}의 서비스 더보기
-          {data.map(({ productTitle, count, productNo, mainImage }) => (
+          {data.products.map(({ productTitle, count, productNo, mainImage }) => (
             <SmallDrawerCard
               key={productNo}
               link={`/drawer/services/${productNo}`}

--- a/src/drawer/hooks/useGetProductByProvider.ts
+++ b/src/drawer/hooks/useGetProductByProvider.ts
@@ -20,6 +20,5 @@ export const useGetProductByProvider = ({
       return getProductByProvider({ providerId, page, category: selectedCategory });
     },
     retry: false,
-    select: (data) => data,
   });
 };

--- a/src/drawer/hooks/useGetProductByProvider.ts
+++ b/src/drawer/hooks/useGetProductByProvider.ts
@@ -20,6 +20,6 @@ export const useGetProductByProvider = ({
       return getProductByProvider({ providerId, page, category: selectedCategory });
     },
     retry: false,
-    select: (data) => data.productList,
+    select: (data) => data,
   });
 };

--- a/src/drawer/pages/Provider/Provider.tsx
+++ b/src/drawer/pages/Provider/Provider.tsx
@@ -30,11 +30,11 @@ export const Provider = () => {
       <StyledProviderContainer $isSmallDesktop={isSmallDesktop}>
         {isSmallDesktop && <CategoryDropdownMenu />}
         <div>
-          <StyledProviderName>{providerId}</StyledProviderName>
+          <StyledProviderName>{data.providerName}</StyledProviderName>
           <StyledDescription>개발자의 서비스를 확인해보세요.</StyledDescription>
         </div>
-        {data.length > 0 ? (
-          <CardLayout data={data} type={'PROVIDER'} />
+        {data.products.length > 0 ? (
+          <CardLayout data={data.products} type={'PROVIDER'} />
         ) : (
           <EmptyScreen type={'PROVIDER'} />
         )}

--- a/src/drawer/types/product.type.ts
+++ b/src/drawer/types/product.type.ts
@@ -55,3 +55,8 @@ export interface GetProductByProviderProps {
   page?: number;
   category?: string;
 }
+
+export interface ProviderProductResponses {
+  providerName: string;
+  products: ProductResult[];
+}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

ProviderProductResponses 구조에 맞게 응답 타입 코드를 수정하였습니다.

- resolved #186 

<img width="1510" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/94633589/86e9b486-9f42-4316-adfd-d1d3fc61ae6f">

### 기존 코드에 영향을 미치는 변경사항

ProviderProductResponses 타입 추가
```ts
export interface ProviderProductResponses {
  providerName: string;
  products: ProductResult[];
}
```

이에 맞게 getProductByProvider와 useGetProductByProvider를 수정하였고 상세페이지와 더보기 컴포넌트는 잘 돌아갈겁니다!

## 3️⃣ 추후 작업

피드백 반영

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
