### PR TITLE
feat: Home 공지사항 API 연결

### DIFF
--- a/src/home/components/Notification/Notification.tsx
+++ b/src/home/components/Notification/Notification.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 
 import { IcNoticeLine } from '@yourssu/design-system-react';
 
+import { useGetAnnouncement } from '@/home/hooks/useGetAnnouncement';
 import { useInterval } from '@/hooks/useInterval';
 
 import {
@@ -12,24 +13,23 @@ import {
   StyledNotificationContainer,
 } from './Notification.style';
 
-const Dummy = [
-  '그거 아시나요?? 지금은 2월이라는 거? 당연함 2월임',
-  '안녕하세요~~ 공지입니다.',
-  '가나다라마바사아자차카타파하갸냐댜랴먀뱌샤야쟈챠캬탸퍄햐거너더러머버서어저처커터퍼허겨녀뎌려며벼셔여져쳐켜텨펴혀',
-  '이거슨 테스트여',
-];
-
-// TODO: 추후 공지사항 API 연결 확인 필요
 export const Notification = () => {
+  const { data, isLoading, isError, error } = useGetAnnouncement();
   const [currentIndex, setCurrentIndex] = useState(1);
   const [activeTransition, setActiveTransition] = useState(true);
   const slideRef = useRef<HTMLDivElement>(null);
-  const notificationArray = [Dummy[Dummy.length - 1], ...Dummy, Dummy[0]].map(
-    (notification, index) => ({
-      id: index + 1,
-      notification,
-    })
-  );
+
+  const announcements = data?.announcementList ?? [];
+
+  const notificationArray =
+    announcements.length > 0
+      ? [announcements[announcements.length - 1], ...announcements, announcements[0]].map(
+          (announcement, index) => ({
+            id: index + 1,
+            notification: announcement.title,
+          })
+        )
+      : [];
 
   useInterval(() => setCurrentIndex((prev) => prev + 1), 5000);
 
@@ -52,7 +52,7 @@ export const Notification = () => {
   }
 
   if (currentIndex === 0) {
-    InfiniteSlideHandler(Dummy.length);
+    InfiniteSlideHandler(announcements.length);
   }
 
   return (
@@ -60,16 +60,24 @@ export const Notification = () => {
       <StyledInnerContainer>
         <IcNoticeLine size="2.25rem" />
         <StyledNotificationContainer>
-          <StyledNotificationArray
-            ref={slideRef}
-            $length={notificationArray.length}
-            $currentIndex={currentIndex}
-            $active={activeTransition}
-          >
-            {notificationArray.map((item) => (
-              <StyledNotification key={item.id}>{item.notification}</StyledNotification>
-            ))}
-          </StyledNotificationArray>
+          {isLoading ? (
+            <StyledNotification>로딩중...</StyledNotification>
+          ) : isError ? (
+            <StyledNotification>Error: {error.message}</StyledNotification>
+          ) : announcements.length === 0 ? (
+            <StyledNotification>공지사항이 없습니다.</StyledNotification>
+          ) : (
+            <StyledNotificationArray
+              ref={slideRef}
+              $length={notificationArray.length}
+              $currentIndex={currentIndex}
+              $active={activeTransition}
+            >
+              {notificationArray.map((item) => (
+                <StyledNotification key={item.id}>{item.notification}</StyledNotification>
+              ))}
+            </StyledNotificationArray>
+          )}
         </StyledNotificationContainer>
       </StyledInnerContainer>
     </StyledContainer>

--- a/src/home/components/Notification/Notification.tsx
+++ b/src/home/components/Notification/Notification.tsx
@@ -15,12 +15,10 @@ import {
 } from './Notification.style';
 
 const NotificationContent = () => {
-  const { data } = useGetAnnouncement();
+  const { data: announcements } = useGetAnnouncement();
   const [currentIndex, setCurrentIndex] = useState(1);
   const [activeTransition, setActiveTransition] = useState(true);
   const slideRef = useRef<HTMLDivElement>(null);
-
-  const announcements = data?.announcementList ?? [];
 
   const notificationArray =
     announcements.length > 0
@@ -53,7 +51,7 @@ const NotificationContent = () => {
   }
 
   if (currentIndex === 0) {
-    InfiniteSlideHandler(announcements.length);
+    InfiniteSlideHandler(announcements?.length);
   }
 
   return (

--- a/src/home/components/Notification/Notification.tsx
+++ b/src/home/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useRef, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 
 import { IcNoticeLine } from '@yourssu/design-system-react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -30,23 +30,24 @@ const NotificationContent = () => {
 
   useInterval(() => setCurrentIndex((prev) => prev + 1), 5000);
 
-  const InfiniteSlideHandler = (nextIndex: number) => {
-    setTimeout(() => {
-      if (slideRef.current) {
-        setActiveTransition(false);
-      }
-      setCurrentIndex(nextIndex);
+  useEffect(() => {
+    const handleInfiniteSlide = (nextIndex: number) => {
       setTimeout(() => {
         if (slideRef.current) {
-          setActiveTransition(true);
+          setActiveTransition(false);
         }
-      }, 100);
-    }, 500);
-  };
-
-  if (currentIndex === notificationArray.length - 1) {
-    InfiniteSlideHandler(0);
-  }
+        setCurrentIndex(nextIndex);
+        setTimeout(() => {
+          if (slideRef.current) {
+            setActiveTransition(true);
+          }
+        }, 100);
+      }, 500);
+    };
+    if (currentIndex === notificationArray.length - 1) {
+      handleInfiniteSlide(0);
+    }
+  }, [currentIndex, notificationArray.length]);
 
   return (
     <StyledNotificationContainer>

--- a/src/home/components/Notification/Notification.tsx
+++ b/src/home/components/Notification/Notification.tsx
@@ -16,18 +16,16 @@ import {
 
 const NotificationContent = () => {
   const { data: announcements } = useGetAnnouncement();
-  const [currentIndex, setCurrentIndex] = useState(1);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [activeTransition, setActiveTransition] = useState(true);
   const slideRef = useRef<HTMLDivElement>(null);
 
   const notificationArray =
     announcements.length > 0
-      ? [announcements[announcements.length - 1], ...announcements, announcements[0]].map(
-          (announcement, index) => ({
-            id: index + 1,
-            notification: announcement.title,
-          })
-        )
+      ? [...announcements, announcements[0]].map((announcement, index) => ({
+          id: index + 1,
+          notification: announcement.title,
+        }))
       : [];
 
   useInterval(() => setCurrentIndex((prev) => prev + 1), 5000);
@@ -47,11 +45,7 @@ const NotificationContent = () => {
   };
 
   if (currentIndex === notificationArray.length - 1) {
-    InfiniteSlideHandler(1);
-  }
-
-  if (currentIndex === 0) {
-    InfiniteSlideHandler(announcements?.length);
+    InfiniteSlideHandler(0);
   }
 
   return (

--- a/src/home/components/Notification/Notification.tsx
+++ b/src/home/components/Notification/Notification.tsx
@@ -1,6 +1,7 @@
-import { useRef, useState } from 'react';
+import { Suspense, useRef, useState } from 'react';
 
 import { IcNoticeLine } from '@yourssu/design-system-react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { useGetAnnouncement } from '@/home/hooks/useGetAnnouncement';
 import { useInterval } from '@/hooks/useInterval';
@@ -13,8 +14,8 @@ import {
   StyledNotificationContainer,
 } from './Notification.style';
 
-export const Notification = () => {
-  const { data, isLoading, isError, error } = useGetAnnouncement();
+const NotificationContent = () => {
+  const { data } = useGetAnnouncement();
   const [currentIndex, setCurrentIndex] = useState(1);
   const [activeTransition, setActiveTransition] = useState(true);
   const slideRef = useRef<HTMLDivElement>(null);
@@ -56,29 +57,39 @@ export const Notification = () => {
   }
 
   return (
+    <StyledNotificationContainer>
+      {announcements.length === 0 ? (
+        <StyledNotification>공지사항이 없습니다.</StyledNotification>
+      ) : (
+        <StyledNotificationArray
+          ref={slideRef}
+          $length={notificationArray.length}
+          $currentIndex={currentIndex}
+          $active={activeTransition}
+        >
+          {notificationArray.map((item) => (
+            <StyledNotification key={item.id}>{item.notification}</StyledNotification>
+          ))}
+        </StyledNotificationArray>
+      )}
+    </StyledNotificationContainer>
+  );
+};
+
+export const Notification = () => {
+  return (
     <StyledContainer>
       <StyledInnerContainer>
         <IcNoticeLine size="2.25rem" />
-        <StyledNotificationContainer>
-          {isLoading ? (
-            <StyledNotification>로딩중...</StyledNotification>
-          ) : isError ? (
+        <ErrorBoundary
+          fallbackRender={({ error }) => (
             <StyledNotification>Error: {error.message}</StyledNotification>
-          ) : announcements.length === 0 ? (
-            <StyledNotification>공지사항이 없습니다.</StyledNotification>
-          ) : (
-            <StyledNotificationArray
-              ref={slideRef}
-              $length={notificationArray.length}
-              $currentIndex={currentIndex}
-              $active={activeTransition}
-            >
-              {notificationArray.map((item) => (
-                <StyledNotification key={item.id}>{item.notification}</StyledNotification>
-              ))}
-            </StyledNotificationArray>
           )}
-        </StyledNotificationContainer>
+        >
+          <Suspense fallback={<StyledNotification>로딩중...</StyledNotification>}>
+            <NotificationContent />
+          </Suspense>
+        </ErrorBoundary>
       </StyledInnerContainer>
     </StyledContainer>
   );

--- a/src/home/hooks/useGetAnnouncement.ts
+++ b/src/home/hooks/useGetAnnouncement.ts
@@ -5,8 +5,7 @@ import { getAnnouncement } from '@/home/apis/getAnnouncement';
 export const useGetAnnouncement = () => {
   return useSuspenseQuery({
     queryKey: ['announcement'],
-    queryFn: () => {
-      return getAnnouncement();
-    },
+    queryFn: getAnnouncement,
+    select: (data) => data.announcementList,
   });
 };

--- a/src/home/hooks/useGetAnnouncement.ts
+++ b/src/home/hooks/useGetAnnouncement.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getAnnouncement } from '@/home/apis/getAnnouncement';
 
 export const useGetAnnouncement = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['announcement'],
     queryFn: () => {
       return getAnnouncement();

--- a/src/home/types/announcement.type.ts
+++ b/src/home/types/announcement.type.ts
@@ -1,3 +1,8 @@
+export interface Announcement {
+  id: number;
+  title: string;
+}
+
 export interface AnnouncementResponse {
-  // TODO: 추후 API 관련 타입 정의 필요
+  announcementList: Announcement[];
 }


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #198 

https://github.com/yourssu/Soomsil-Web/assets/87332713/b6fc71dc-de7b-4cb4-90f6-53d9001d2d64

- Home 공지사항 API 연결

<img width="336" alt="스크린샷 2024-05-30 오전 3 42 27" src="https://github.com/yourssu/Soomsil-Web/assets/87332713/57deeecb-e2ee-47cc-b9c9-53e87ed63682">

- 공지사항이 없을 때 (빈 배열일 때)
이 부분 제가 임의로 `공지사항이 없습니다.`로 정했는데 이 부분도 디자인팀과 논의를 해봐야 할까요? 
공지사항이 없을 때도 존재하는지는 어느 팀에 여쭤봐야 할까요?? ㅜㅜ 열심히 찾긴 했는데 없어서 포기했습니닷

<img width="396" alt="스크린샷 2024-05-30 오전 3 07 55" src="https://github.com/yourssu/Soomsil-Web/assets/87332713/4ba6f7ef-aca2-41cd-af41-333ef500c759">

- 로딩중 일 때

<img width="569" alt="스크린샷 2024-05-30 오전 3 08 00" src="https://github.com/yourssu/Soomsil-Web/assets/87332713/4344d165-25f3-49ad-a268-dad5eee6c1e7">

- error 일 때

## 2️⃣ 알아두시면 좋아요!
- 기존에 있던 코드에서 더미 데이터를 제거하고 `useGetAnnouncement();`를 사용해 데이터를 정의(`announcements`)하여 공지사항을 보여줍니다.
- 기존에 있던 `getAnnouncement.ts`에서 공지사항 API를 호출, `useGetAnnouncement.ts`에서 불러온 데이터 캐싱하는 구조입니다.
- 전부 구현되어 있어서 타입 구현과 더미 대신 데이터로 교체만 했습니다!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
