### PR TITLE
fix: 회원탈퇴 후 유저정보가 남아있는 버그 수정

### DIFF
--- a/src/home/apis/postWithdraw.ts
+++ b/src/home/apis/postWithdraw.ts
@@ -1,21 +1,9 @@
-import { isAxiosError } from 'axios';
-
 import { authClient } from '@/apis';
-import { PostWithdrawResponse, AuthErrorData } from '@/home/types/Auth.type';
 import { api } from '@/service/TokenService';
 
-export const postWithdraw = async (): Promise<PostWithdrawResponse> => {
-  try {
-    await authClient.post(
-      '/auth/withdraw',
-      {},
-      {
-        headers: api.headers,
-      }
-    );
-    return { success: true };
-  } catch (error) {
-    if (isAxiosError<AuthErrorData>(error)) return { success: false, error };
-    return Promise.reject(error);
-  }
+export const postWithdraw = async (data: object) => {
+  const res = await authClient.post('/auth/withdraw', data, {
+    headers: api.headers,
+  });
+  return res.data;
 };

--- a/src/home/apis/postWithdraw.ts
+++ b/src/home/apis/postWithdraw.ts
@@ -13,7 +13,6 @@ export const postWithdraw = async (): Promise<PostWithdrawResponse> => {
         headers: api.headers,
       }
     );
-    api.logout();
     return { success: true };
   } catch (error) {
     if (isAxiosError<AuthErrorData>(error)) return { success: false, error };

--- a/src/home/pages/Withdraw/Withdraw.tsx
+++ b/src/home/pages/Withdraw/Withdraw.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import Logo from '@/assets/soomsil_logo.svg';
 import { postWithdraw } from '@/home/apis/postWithdraw';
 import { WithdrawSuccess } from '@/home/components/WithdrawSuccess/WithdrawSuccess';
+import { useResetUserInfo } from '@/hooks/useResetUserInfo';
 
 import {
   StyledButtonText,
@@ -22,6 +23,7 @@ export const Withdraw = () => {
   const navigate = useNavigate();
   const [agreed, setAgreed] = useState(false);
   const [draw, setDraw] = useState(false);
+  const resetUserInfo = useResetUserInfo();
 
   const handleGoToHome = () => {
     navigate('/');
@@ -36,6 +38,7 @@ export const Withdraw = () => {
       const { success, error } = await postWithdraw();
       if (success) {
         setDraw((prevDraw) => !prevDraw);
+        resetUserInfo();
       } else if (error) {
         alert(`탈퇴 처리에 실패했습니다: ${error.message}`);
       }

--- a/src/home/pages/Withdraw/Withdraw.tsx
+++ b/src/home/pages/Withdraw/Withdraw.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
 import { BoxButton, CheckBox } from '@yourssu/design-system-react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 
 import Logo from '@/assets/soomsil_logo.svg';
-import { postWithdraw } from '@/home/apis/postWithdraw';
+import { Fallback } from '@/components/Fallback/Fallback';
 import { WithdrawSuccess } from '@/home/components/WithdrawSuccess/WithdrawSuccess';
-import { useResetUserInfo } from '@/hooks/useResetUserInfo';
+import { usePostWithdraw } from '@/hooks/usePostWithdraw';
 
 import {
   StyledButtonText,
@@ -23,7 +24,7 @@ export const Withdraw = () => {
   const navigate = useNavigate();
   const [agreed, setAgreed] = useState(false);
   const [draw, setDraw] = useState(false);
-  const resetUserInfo = useResetUserInfo();
+  const withdrawMutation = usePostWithdraw();
 
   const handleGoToHome = () => {
     navigate('/');
@@ -33,61 +34,63 @@ export const Withdraw = () => {
     setAgreed((prevAgreed) => !prevAgreed);
   };
 
-  const handleWithdrawAgree = async () => {
-    try {
-      const { success, error } = await postWithdraw();
-      if (success) {
-        setDraw((prevDraw) => !prevDraw);
-        resetUserInfo();
-      } else if (error) {
-        alert(`탈퇴 처리에 실패했습니다: ${error.message}`);
+  const handleWithdrawAgree = () => {
+    withdrawMutation.mutate(
+      {},
+      {
+        onSuccess: () => {
+          setDraw((prevDraw) => !prevDraw);
+        },
       }
-    } catch (error) {
-      if (error instanceof Error) {
-        alert(`탈퇴 처리 중 오류가 발생했습니다: ${error.message}`);
-      } else {
-        alert(`알 수 없는 오류가 발생했습니다`);
-      }
-    }
+    );
   };
 
   return (
-    <StyledWrapper>
-      <img onClick={handleGoToHome} src={Logo} alt="Logo-image" width={180} height={38} />
-      <StyledWithdrawContainer>
-        {draw ? (
-          <WithdrawSuccess onConfirm={handleGoToHome} />
-        ) : (
-          <>
-            <StyledTitleText>계정 탈퇴</StyledTitleText>
-            <StyledSubTitleText>계정 탈퇴 전 꼭 확인하세요.</StyledSubTitleText>
-            <StyledText>
-              <StyledListItem>탈퇴하는 즉시 데이터가 제거되며, 복구가 불가능합니다.</StyledListItem>
-              <StyledListItem>
-                닉네임, 이메일 등 사용자를 특정할 수 있는 모든 계정 정보가 지워집니다.
-              </StyledListItem>
-              <StyledListItem>
-                등록된 글이나 댓글의 삭제를 원한다면 탈퇴 이전에 삭제하시기 바랍니다.
-              </StyledListItem>
-            </StyledText>
-            <StyledLeft>
-              <CheckBox size="medium" isSelected={agreed} onClick={handleCheckAgree} type="button">
-                <StyledButtonText>안내사항을 확인하였으며, 이에 동의합니다.</StyledButtonText>
-              </CheckBox>
-            </StyledLeft>
-            <BoxButton
-              style={{ width: '100%' }}
-              rounding={8}
-              size="large"
-              variant="filled"
-              onClick={handleWithdrawAgree}
-              disabled={!agreed}
-            >
-              탈퇴하기
-            </BoxButton>
-          </>
-        )}
-      </StyledWithdrawContainer>
-    </StyledWrapper>
+    <ErrorBoundary FallbackComponent={Fallback}>
+      <StyledWrapper>
+        <img onClick={handleGoToHome} src={Logo} alt="Logo-image" width={180} height={38} />
+        <StyledWithdrawContainer>
+          {draw ? (
+            <WithdrawSuccess onConfirm={handleGoToHome} />
+          ) : (
+            <>
+              <StyledTitleText>계정 탈퇴</StyledTitleText>
+              <StyledSubTitleText>계정 탈퇴 전 꼭 확인하세요.</StyledSubTitleText>
+              <StyledText>
+                <StyledListItem>
+                  탈퇴하는 즉시 데이터가 제거되며, 복구가 불가능합니다.
+                </StyledListItem>
+                <StyledListItem>
+                  닉네임, 이메일 등 사용자를 특정할 수 있는 모든 계정 정보가 지워집니다.
+                </StyledListItem>
+                <StyledListItem>
+                  등록된 글이나 댓글의 삭제를 원한다면 탈퇴 이전에 삭제하시기 바랍니다.
+                </StyledListItem>
+              </StyledText>
+              <StyledLeft>
+                <CheckBox
+                  size="medium"
+                  isSelected={agreed}
+                  onClick={handleCheckAgree}
+                  type="button"
+                >
+                  <StyledButtonText>안내사항을 확인하였으며, 이에 동의합니다.</StyledButtonText>
+                </CheckBox>
+              </StyledLeft>
+              <BoxButton
+                style={{ width: '100%' }}
+                rounding={8}
+                size="large"
+                variant="filled"
+                onClick={handleWithdrawAgree}
+                disabled={!agreed || withdrawMutation.isPending}
+              >
+                탈퇴하기
+              </BoxButton>
+            </>
+          )}
+        </StyledWithdrawContainer>
+      </StyledWrapper>
+    </ErrorBoundary>
   );
 };

--- a/src/hooks/usePostWithdraw.ts
+++ b/src/hooks/usePostWithdraw.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { postWithdraw } from '@/home/apis/postWithdraw';
+
+import { useResetUserInfo } from './useResetUserInfo';
+
+export const usePostWithdraw = () => {
+  const resetUserInfo = useResetUserInfo();
+
+  return useMutation({
+    mutationFn: postWithdraw,
+    onSuccess: () => {
+      resetUserInfo();
+    },
+    throwOnError: true,
+  });
+};

--- a/src/hooks/useResetUserInfo.ts
+++ b/src/hooks/useResetUserInfo.ts
@@ -1,16 +1,13 @@
 import { useSetRecoilState } from 'recoil';
 
 import { LogInState } from '@/home/recoil/LogInState';
-import { UserState } from '@/home/recoil/UserState';
 import { api } from '@/service/TokenService';
 
 export const useResetUserInfo = () => {
   const resetLoginState = useSetRecoilState(LogInState);
-  const resetUserState = useSetRecoilState(UserState);
 
   return () => {
     resetLoginState(false);
-    resetUserState(null);
     api.logout();
   };
 };

--- a/src/hooks/useResetUserInfo.ts
+++ b/src/hooks/useResetUserInfo.ts
@@ -4,18 +4,13 @@ import { LogInState } from '@/home/recoil/LogInState';
 import { UserState } from '@/home/recoil/UserState';
 import { api } from '@/service/TokenService';
 
-const resetUserInfo = (
-  resetLoginState: (value: boolean) => void,
-  resetUserState: (value: null) => void
-) => {
-  resetLoginState(false);
-  resetUserState(null);
-  api.logout();
-};
-
 export const useResetUserInfo = () => {
   const resetLoginState = useSetRecoilState(LogInState);
   const resetUserState = useSetRecoilState(UserState);
 
-  return () => resetUserInfo(resetLoginState, resetUserState);
+  return () => {
+    resetLoginState(false);
+    resetUserState(null);
+    api.logout();
+  };
 };

--- a/src/hooks/useResetUserInfo.ts
+++ b/src/hooks/useResetUserInfo.ts
@@ -1,0 +1,21 @@
+import { useSetRecoilState } from 'recoil';
+
+import { LogInState } from '@/home/recoil/LogInState';
+import { UserState } from '@/home/recoil/UserState';
+import { api } from '@/service/TokenService';
+
+const resetUserInfo = (
+  resetLoginState: (value: boolean) => void,
+  resetUserState: (value: null) => void
+) => {
+  resetLoginState(false);
+  resetUserState(null);
+  api.logout();
+};
+
+export const useResetUserInfo = () => {
+  const resetLoginState = useSetRecoilState(LogInState);
+  const resetUserState = useSetRecoilState(UserState);
+
+  return () => resetUserInfo(resetLoginState, resetUserState);
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #204 

### 버그 픽스
- LoginState랑 UserState가 초기화 코드 누락 해결
<img width="232" alt="스크린샷 2024-06-03 오후 3 50 52" src="https://github.com/yourssu/Soomsil-Web/assets/87332713/a78364cc-54af-4dd5-b2b7-0ce8dfba8ad8">

- 로그인 했을 때
<img width="230" alt="스크린샷 2024-06-03 오후 3 51 06" src="https://github.com/yourssu/Soomsil-Web/assets/87332713/93ee455e-983b-4922-9f67-65cb123b507f">

- 계정 탈퇴 후

## 2️⃣ 알아두시면 좋아요!
로그아웃 `api.logout`과 LoginState를 `false`로, UserState를 `null`로 전부 초기화하는 `useResetUserInfo` 훅을 만들었습니다.
로그아웃에서도 LoginState, UserState 전부 초기화 해야하면 갖다 써도 될 것 같습니당

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
