### PR TITLE
feat: 서랍장 서비스 등록 페이지 네이티브 웹뷰 연결

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -20,7 +20,7 @@ export const authClient = axios.create({
 });
 
 soomsilClient.interceptors.request.use((config) => {
-  if (config.headers && api.getRefreshToken()) {
+  if (config.headers && api.getAccessToken()) {
     config.headers.Authorization = `Bearer ${api.getAccessToken()}`;
   }
   return config;

--- a/src/drawer/components/Layout/Layout.tsx
+++ b/src/drawer/components/Layout/Layout.tsx
@@ -6,7 +6,6 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 
 import { Footer } from '../Footer/Footer';
 import { Header } from '../Header/Header';
-import { MobileRegisterHeader } from '../Header/MobileRegisterHeader';
 
 import { StyledLayout } from './Layout.style';
 
@@ -18,7 +17,7 @@ export const Layout = () => {
 
   return (
     <StyledLayout>
-      {isMobileRegisterRoute ? <MobileRegisterHeader /> : <Header />}
+      {isMobileRegisterRoute ? null : <Header />}
       <ErrorBoundary
         fallbackRender={(fallbackProps) => <Fallback {...fallbackProps} />}
         resetKeys={[location.pathname]}

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -24,6 +24,22 @@ import {
   StyledRightContainer,
 } from './Register.style';
 
+declare global {
+  interface Window {
+    Android: {
+      getAccessToken: () => void;
+    };
+    webkit: {
+      messageHandlers: {
+        ios: {
+          postMessage: (message: string) => void;
+        };
+      };
+    };
+    setAccessToken: (token: string) => void;
+  }
+}
+
 export const Register = () => {
   const methods = useForm<RegisterFormValues>({ defaultValues: registerFormDefaultValue });
 
@@ -52,7 +68,7 @@ export const Register = () => {
     };
 
     window.setAccessToken = (accessToken: string) => {
-      api.setAccessToken(accessToken);
+      api.setAccessToken(accessToken, Date.now() + 5 * 60 * 1000);
     };
 
     getAccessTokenFromNative();

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { BoxButton } from '@yourssu/design-system-react';
-import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 
 import { Loading } from '@/components/Loading/Loading';
 import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
@@ -15,6 +15,7 @@ import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
 import { registerFormDefaultValue } from '@/drawer/constants/registerFormDefaultValue.constant';
 import { usePostProduct } from '@/drawer/hooks/usePostProduct';
 import { RegisterFormValues } from '@/drawer/types/form.type';
+import { api } from '@/service/TokenService';
 
 import {
   StyledContainer,
@@ -40,6 +41,22 @@ export const Register = () => {
       registerProductMutation.mutate(data);
     }
   };
+
+  useEffect(() => {
+    const getAccessTokenFromNative = () => {
+      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.ios) {
+        window.webkit.messageHandlers.ios.postMessage('getAccessToken');
+      } else if (window.Android && window.Android.getAccessToken) {
+        window.Android.getAccessToken();
+      }
+    };
+
+    window.setAccessToken = (accessToken: string) => {
+      api.setAccessToken(accessToken);
+    };
+
+    getAccessTokenFromNative();
+  }, []);
 
   useEffect(() => {
     if (methods.formState.errors) {

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -29,6 +29,7 @@ declare global {
   interface Window {
     Android: {
       getAccessToken: () => void;
+      onRegisterSuccess: () => void;
     };
     webkit: {
       messageHandlers: {
@@ -58,6 +59,12 @@ export const Register = () => {
     if (isChecked) {
       registerProductMutation.mutate(data, {
         onSuccess: () => {
+          if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.ios) {
+            window.webkit.messageHandlers.ios.postMessage('onRegisterSuccess');
+          } else if (window.Android && window.Android.onRegisterSuccess) {
+            window.Android.onRegisterSuccess();
+          }
+
           navigate('/drawer/myDrawers');
         },
       });

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { BoxButton } from '@yourssu/design-system-react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 import { Loading } from '@/components/Loading/Loading';
 import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
@@ -42,6 +43,7 @@ declare global {
 
 export const Register = () => {
   const methods = useForm<RegisterFormValues>({ defaultValues: registerFormDefaultValue });
+  const navigate = useNavigate();
 
   const [linkExist, setLinkExist] = useState(true);
   const [isChecked, setIsChecked] = useState(false);
@@ -54,7 +56,11 @@ export const Register = () => {
 
   const handleSubmit: SubmitHandler<RegisterFormValues> = (data) => {
     if (isChecked) {
-      registerProductMutation.mutate(data);
+      registerProductMutation.mutate(data, {
+        onSuccess: () => {
+          navigate('/drawer/myDrawers');
+        },
+      });
     }
   };
 

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -68,7 +68,7 @@ export const Register = () => {
     };
 
     window.setAccessToken = (accessToken: string) => {
-      api.setAccessToken(accessToken, Date.now() + 5 * 60 * 1000);
+      api.setAccessToken(accessToken, Date.now() + 60 * 60 * 1000);
     };
 
     getAccessTokenFromNative();

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -151,8 +151,8 @@ export const Router = () => {
             <Route path="services/:serviceId/edit" element={<ServiceEdit />} />
             <Route path="services/:serviceId" element={<ServiceDetail />} />
             <Route path="rankings" element={<Ranking />} />
+            <Route path="register" element={<Register />} />
             <Route element={<PrivateRoute isModalOpen={true} modalPath="/drawer" />}>
-              <Route path="register" element={<Register />} />
               <Route path="myDrawers" element={<MyDrawer />} />
             </Route>
             <Route path="/drawer/newRelease" element={<NewRelease />} />


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #184 

### 기존 코드에 영향을 미치지 않는 변경사항
- `drawer/pages/Register.tsx`
  - Android, ios 웹뷰로 서랍장 서비스 등록 페이지에 접속하면 네이티브에서 유저의 `accessToken`을 받아오는 기능을 구현하였습니다.

## 2️⃣ 알아두시면 좋아요!
- Android 웹뷰에서 서랍장 서비스 등록 페이지에 접속
  1. Andorid 네이티브에 정의된 함수인 `Android.getAccessToken()` 호출
  2. Andoird 네이티브에서는 유저의 `accessToken`을 가져와 웹뷰에 정의된 자바스크립트 함수인 `window.setAccessToken()`을 호출
  3. `setAccessToken` 함수는 네이티브로부터 `accessToken`을 받아 `api` 싱글톤 객체에 등록 -> 추후 API 요청에 이용

- ios 웹뷰에서 서랍장 서비스 등록 페이지에 접속
  1. iOS 네이티브에 정의된 컨트롤러에 유저의 `accessToken`을 요청(`window.webkit.messageHandlers.ios.postMessage("getAccessToken")`)
  2. ios 네이티브에서 유저의 `accessToken`을 가져와 웹뷰에 정의된 자바스크립트 함수인 `window.setAccessToken()`을 호출
  3. `setAccessToken` 함수는 네이티브로부터 `accessToken`을 받아 `api` 싱글톤 객체에 등록 -> 추후 API 요청에 이용

## 3️⃣ 추후 작업
- 웹뷰에서 정상적으로 서랍장 서비스 등록이 이루어지는지 확인하기 

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
