### PR TITLE
fix: 비밀번호 정규식 및 코멘트 변경

### DIFF
--- a/src/home/components/ChangePasswordContents/NewPasswordForm/NewPasswordForm.tsx
+++ b/src/home/components/ChangePasswordContents/NewPasswordForm/NewPasswordForm.tsx
@@ -38,12 +38,14 @@ export const NewPasswordForm = ({ sessionToken }: NewPasswordFormProps) => {
       <StyledInputContainer>
         <StyledInputTitle>새로운 비밀번호를 입력해주세요.</StyledInputTitle>
         <PasswordTextField
-          placeholder="숫자와 영문자 조합으로 8자 이상 입력해주세요."
+          placeholder="숫자, 영문자, 특수문자 조합으로 8자 이상 입력해주세요"
           value={newPassword}
           onChange={(e) => handleNewPasswordChange(e.target.value)}
           isNegative={isNewPasswordFieldNegative}
           helperLabel={
-            isNewPasswordFieldNegative ? '숫자와 영문자 조합으로 8자 이상 입력해주세요.' : ''
+            isNewPasswordFieldNegative
+              ? '숫자, 영문자, 특수문자 조합으로 8자 이상 입력해주세요'
+              : ''
           }
         />
         <StyledInputAnimation

--- a/src/home/components/SignupContents/SignupForm/SignupForm.tsx
+++ b/src/home/components/SignupContents/SignupForm/SignupForm.tsx
@@ -39,7 +39,7 @@ export const SignupForm = ({ email, onConfirm }: SignupFormProps) => {
       />
       <PasswordTextField
         fieldLabel="사용할 비밀번호를 입력해주세요."
-        helperLabel="숫자와 영문자 조합으로 8자 이상 입력해주세요"
+        helperLabel="숫자, 영문자, 특수문자 조합으로 8자 이상 입력해주세요"
         placeholder="비밀번호"
         isNegative={!isPasswordValid && passwordValidOnce.current}
         onChange={(e) => {

--- a/src/hooks/useSignupFormValidator.ts
+++ b/src/hooks/useSignupFormValidator.ts
@@ -6,9 +6,16 @@ export const useSignupFormValidation = (nickname: string, password: string) => {
   const nicknameValidOnce = useRef(false);
   const passwordValidOnce = useRef(false);
 
+  function isBlank(value: string): boolean {
+    return /^\s*$/.test(value);
+  }
+
   const isNicknameValid = useMemo(() => {
     return (
-      nickname.length >= 2 && nickname.length <= 12 && hasNumberOrEnglishOrHangulOrSpace(nickname)
+      nickname.length >= 2 &&
+      nickname.length <= 12 &&
+      hasNumberOrEnglishOrHangulOrSpace(nickname) &&
+      !isBlank(nickname)
     );
   }, [nickname]);
 

--- a/src/hooks/useSignupFormValidator.ts
+++ b/src/hooks/useSignupFormValidator.ts
@@ -1,19 +1,21 @@
 import { useMemo, useRef } from 'react';
 
+import { hasNumberAndEnglishWithSymbols, hasNumberOrEnglishOrHangulOrSpace } from '@yourssu/utils';
+
 export const useSignupFormValidation = (nickname: string, password: string) => {
   const nicknameValidOnce = useRef(false);
   const passwordValidOnce = useRef(false);
 
-  const hasOnlyNumberAndEnglish = (value: string) => /^[a-zA-Z0-9]*$/.test(value);
-  const hasOnlyNumberEnglishAndHangul = (value: string) =>
-    /^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9|]*$/.test(value);
-
   const isNicknameValid = useMemo(() => {
-    return nickname.length >= 2 && nickname.length <= 12 && hasOnlyNumberEnglishAndHangul(nickname);
+    return (
+      nickname.length >= 2 && nickname.length <= 12 && hasNumberOrEnglishOrHangulOrSpace(nickname)
+    );
   }, [nickname]);
 
   const isPasswordValid = useMemo(() => {
-    return password.length >= 8 && hasOnlyNumberAndEnglish(password);
+    return (
+      password.length >= 8 && password.length <= 100 && hasNumberAndEnglishWithSymbols(password)
+    );
   }, [password]);
 
   return {


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #203

### 기존 코드에 영향을 미치지 않는 변경사항

- 없습니다.

### 기존 코드에 영향을 미치는 변경사항

#### 코멘트를 수정했습니다.
- ```src/home/components/SignupContents/SignupForm/SignupForm.tsx```
- ```src/home/components/ChangePasswordContents/NewPasswordForm/NewPasswordForm.tsx```

#### 정규식을 수정했습니다.
- ```src/hooks/useSignupFormValidator.ts```
- @yourssu/utils 패키지의 ```hasNumberOrEnglishOrHangulOrSpace```, ```hasNumberAndEnglishWithSymbols```를 사용했습니다.
- 이슈에 올라와 있는 정규식의 조건과 일치합니다.

## 2️⃣ 알아두시면 좋아요!

```hasNumberAndEnglishWithSymbols``` 함수에서 허용하는 특수문자는 ```! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ \ ` { | } ~ ₩```입니다.

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
