### PR TITLE
fix: 회원 가입 중복 호출 방지 

### DIFF
--- a/src/home/components/SignupContents/EmailForm/EmailForm.tsx
+++ b/src/home/components/SignupContents/EmailForm/EmailForm.tsx
@@ -3,6 +3,7 @@ import { BoxButton, PlainButton, SuffixTextField } from '@yourssu/design-system-
 import { EMAIL_DOMAIN } from '@/constants/email.constant';
 import { EmailFormProps } from '@/home/components/SignupContents/EmailForm/EmailForm.type.ts';
 import { useEmailForm } from '@/home/components/SignupContents/EmailForm/useEmailForm.ts';
+import { usePreventDuplicateClick } from '@/hooks/usePreventDuplicateClick.ts';
 
 import {
   StyledSignupButtonText,
@@ -18,7 +19,8 @@ import {
 } from './EmailForm.style';
 
 export const EmailForm = ({ onConfirm }: EmailFormProps) => {
-  const { email, emailSending, emailError, onEmailSubmit, onChange } = useEmailForm({ onConfirm });
+  const { email, emailError, onEmailSubmit, onChange } = useEmailForm({ onConfirm });
+  const { disabled, handleClick } = usePreventDuplicateClick();
 
   return (
     <StyledSignupContentContainer>
@@ -47,8 +49,8 @@ export const EmailForm = ({ onConfirm }: EmailFormProps) => {
           size="large"
           variant="filled"
           rounding={8}
-          disabled={email === '' || emailSending}
-          onClick={onEmailSubmit}
+          disabled={email === '' || disabled}
+          onClick={() => handleClick(onEmailSubmit)}
         >
           <StyledSignupButtonText>인증 메일 받기</StyledSignupButtonText>
         </BoxButton>

--- a/src/home/components/SignupContents/EmailForm/useEmailForm.ts
+++ b/src/home/components/SignupContents/EmailForm/useEmailForm.ts
@@ -7,7 +7,6 @@ import { useFullEmail } from '@/hooks/useFullEmail';
 export const useEmailForm = ({ onConfirm }: EmailFormProps) => {
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | undefined>(undefined);
-  const [emailSending, setEmailSending] = useState(false);
   const fullEmail = useFullEmail(email);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -15,17 +14,13 @@ export const useEmailForm = ({ onConfirm }: EmailFormProps) => {
   };
 
   const onEmailSubmit = async () => {
-    setEmailSending(true);
-
     const res = await postAuthVerificationEmail({ email: fullEmail, verificationType: 'SIGN_UP' });
     if (res.data) {
       onConfirm(fullEmail);
     } else {
       setEmailError(res.error?.response?.data.message || '이메일을 다시 확인해주세요.');
     }
-
-    setEmailSending(false);
   };
 
-  return { email, emailError, emailSending, onChange, onEmailSubmit };
+  return { email, emailError, onChange, onEmailSubmit };
 };

--- a/src/home/components/SignupContents/SignupForm/SignupForm.tsx
+++ b/src/home/components/SignupContents/SignupForm/SignupForm.tsx
@@ -2,6 +2,7 @@ import { BoxButton, PasswordTextField, SimpleTextField } from '@yourssu/design-s
 
 import { SignupFormProps } from '@/home/components/SignupContents/SignupForm/SignUpForm.type.ts';
 import { useSignUpForm } from '@/home/components/SignupContents/SignupForm/useSignUpForm.ts';
+import { usePreventDuplicateClick } from '@/hooks/usePreventDuplicateClick.ts';
 import { useSignupFormValidation } from '@/hooks/useSignupFormValidator.ts';
 
 import {
@@ -18,6 +19,8 @@ export const SignupForm = ({ email, onConfirm }: SignupFormProps) => {
 
   const { nicknameValidOnce, passwordValidOnce, isFormValid, isNicknameValid, isPasswordValid } =
     useSignupFormValidation(nickname, password);
+
+  const { disabled, handleClick } = usePreventDuplicateClick();
 
   return (
     <StyledSignupContentContainer>
@@ -51,8 +54,8 @@ export const SignupForm = ({ email, onConfirm }: SignupFormProps) => {
         rounding={8}
         size="large"
         variant="filled"
-        onClick={onFormConfirm}
-        disabled={!isFormValid}
+        onClick={() => handleClick(onFormConfirm)}
+        disabled={!isFormValid || disabled}
       >
         <StyledSignupButtonText>회원가입</StyledSignupButtonText>
       </BoxButton>

--- a/src/hooks/usePreventDuplicateClick.ts
+++ b/src/hooks/usePreventDuplicateClick.ts
@@ -1,0 +1,20 @@
+import { useCallback, useRef, useState } from 'react';
+
+export const usePreventDuplicateClick = () => {
+  const [disabled, setDisabled] = useState(false);
+  const loadingRef = useRef(false);
+
+  const handleClick = useCallback(async (callback: () => Promise<void>) => {
+    if (loadingRef.current) return;
+
+    loadingRef.current = true;
+    setDisabled(true);
+
+    await callback();
+
+    loadingRef.current = false;
+    setDisabled(false);
+  }, []);
+
+  return { disabled, handleClick };
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #207 

### 기존 코드에 영향을 미치지 않는 변경사항

```usePreventDuplicateClick``` 훅을 추가했습니다.

[참고용 블로그](https://happysisyphe.tistory.com/72)

위 블로그를 참고해서 제작했습니다.

### 기존 코드에 영향을 미치는 변경사항

#### 회원가입 프로세스 수정
```usePreventDuplicateClick``` 훅을 적용했습니다.
- ```src/home/components/SignupContents/EmailForm/EmailForm.tsx```
- ```src/home/components/SignupContents/SignupForm/SignupForm.tsx```

```emailSending``` state를 제거했습니다.

- ```src/home/components/SignupContents/EmailForm/useEmailForm.ts```

### 버그 픽스

- 회원가입 중복 요청을 방지해 '잘못된 데이터 요청입니다.' alert가 발생하지 않습니다.

## 2️⃣ 알아두시면 좋아요!

```usePreventDuplicateClick```은 ```useRef```와 ```useState```를 동시에 사용합니다. 
- ```useState```는 상태가 변경되는 즉시 반영되지 않기에 api 요청 직후 중복 호출을 막기 위해서는 ```useRef```를 사용하는 것이 안전합니다.
- ```useRef```는 re-rendering을 발생 시키지 않습니다. 따라서 버튼이 disabled 될 때 re-rendering을 발생 시키기 위해선 ```useState```를 사용해야 합니다.

## 3️⃣ 추후 작업

Yrano react package에 ```usePreventDuplicateClick```를 추가해서 범용적으로 사용할 수 있도록 합니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
