### PR TITLE
fix: 프로덕트 이미지 등록 조건 서버와 통일하기

### DIFF
--- a/src/drawer/components/OverviewImage/OverviewFileUpload/OverviewFileUpload.style.ts
+++ b/src/drawer/components/OverviewImage/OverviewFileUpload/OverviewFileUpload.style.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Z_INDEX } from '@/constants/zIndex.constant';
 
 export const StyledFileUploadLabel = styled.label`
+  cursor: pointer;
   position: absolute;
   padding: 0.48rem 1.56rem;
   border-radius: 0.5rem;

--- a/src/drawer/components/OverviewImage/OverviewFileUpload/OverviewFileUpload.tsx
+++ b/src/drawer/components/OverviewImage/OverviewFileUpload/OverviewFileUpload.tsx
@@ -30,7 +30,7 @@ export const OverviewFileUpload = ({
       <input
         id={`overviewFile${index}`}
         type="file"
-        accept="image/*"
+        accept=".jpg, .jpeg, .png, .gif"
         style={{ display: 'none' }}
         onChange={(e) => handleInputChange(e, index)}
       />

--- a/src/drawer/components/OverviewImage/OverviewImage.tsx
+++ b/src/drawer/components/OverviewImage/OverviewImage.tsx
@@ -2,6 +2,8 @@ import { ChangeEvent, useState, useEffect, useRef } from 'react';
 
 import { useFormContext } from 'react-hook-form';
 
+import { ALLOWED_IMAGE_TYPE } from '@/drawer/constants/image.constant';
+
 import { OverviewFileUpload } from './OverviewFileUpload/OverviewFileUpload';
 import {
   StyledImageUpload,
@@ -24,10 +26,10 @@ export const OverviewImage = () => {
   const handleFileChange = (file: File | undefined, index: number) => {
     setFiles((prevFiles) => {
       const newFiles = [...prevFiles];
-      if (file && file.type.substring(0, 5) === 'image') {
+      if (file && ALLOWED_IMAGE_TYPE.includes(file.type)) {
         newFiles[index] = file;
       } else {
-        alert('이미지 파일을 첨부해주세요.');
+        alert('이미지 포맷은 jpg, jpeg, png, gif 중 하나여야 합니다.');
       }
       return newFiles;
     });

--- a/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
+++ b/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
@@ -4,6 +4,8 @@ import { IcPlusLine, IconContext } from '@yourssu/design-system-react';
 import { useFormContext } from 'react-hook-form';
 import { useTheme } from 'styled-components';
 
+import { ALLOWED_IMAGE_TYPE } from '@/drawer/constants/image.constant';
+
 import {
   StyledThumbnailContainer,
   StyledThumbnailDescription,
@@ -30,10 +32,10 @@ export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
   const handleChangeImg = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files !== null) {
       const file = event.target.files[0];
-      if (file && file.type.substring(0, 5) === 'image') {
+      if (file && ALLOWED_IMAGE_TYPE.includes(file.type)) {
         setPostImg(file);
       } else {
-        alert('이미지 파일을 첨부해주세요.');
+        alert('이미지 포맷은 jpg, jpeg, png, gif 중 하나여야 합니다.');
         setValue(name, null);
         setPostImg(null);
       }

--- a/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
+++ b/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
@@ -67,7 +67,7 @@ export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
       <input
         id="inputFile"
         type="file"
-        accept="image/*"
+        accept=".jpg, .jpeg, .png, .gif"
         onChange={(event) => {
           handleChangeImg(event);
           onChange(event);

--- a/src/drawer/constants/image.constant.ts
+++ b/src/drawer/constants/image.constant.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_IMAGE_TYPE = ['image/jpeg', 'image/png', 'image/gif'];


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #225

### 버그 픽스

서버에서는 jpg jpeg png gif 만 받길래 클라이언트 코드도 통일함

|||
|:---:|:---:|
|전|![before_format](https://github.com/yourssu/Soomsil-Web/assets/87255462/5ab7dfcc-9096-4d08-a6ee-f2ee389c7f9c)|
|후|![format](https://github.com/yourssu/Soomsil-Web/assets/87255462/13990276-bb96-4ea1-84e0-207aa394ac33)|

accept는 필터링용이지 완전히 막을 순 없어서 (파일 탐색기에서 `모든 파일`로 바꿔서 첨부할 수 있음)
안되는 거 넣으면 alert 뜨게 코드도 같이 수정했어요

![image_error](https://github.com/yourssu/Soomsil-Web/assets/87255462/9bc78ae9-1697-42d0-9ca6-e9bf4b65e56c)


## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
