### PR TITLE
feat: `UserInformationCard`에 현재 로그인 중인 사용자 정보 넣기

### DIFF
--- a/src/home/components/UserInformationCard/UserInformationCard.tsx
+++ b/src/home/components/UserInformationCard/UserInformationCard.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { BoxButton, IcSettingLine, SimpleTextField } from '@yourssu/design-system-react';
 import { useTheme } from 'styled-components';
 
-import Ppussung from '@/assets/defaultProfile.png';
 import { ProfileSvg } from '@/components/ProfileSvg/ProfileSVG';
+import { useGetUserData } from '@/home/hooks/useGetUserData';
 
 import {
   StyledButtonContainer,
@@ -16,15 +16,10 @@ import {
   StyledUserNickname,
 } from './UserInformationCard.style';
 
-const Dummy = {
-  name: '김뿌슝',
-  mail: 'ppussung@yourssu.com',
-  image: Ppussung,
-};
-
 export const UserInformationCard = () => {
+  const { data: currentUser } = useGetUserData();
   const [activeEditMode, setAcitveEditMode] = useState(false);
-  const [nickname, setNickname] = useState(Dummy.name);
+  const [nickname, setNickname] = useState<string>('');
   const theme = useTheme();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -33,56 +28,60 @@ export const UserInformationCard = () => {
 
   return (
     <StyledContainer>
-      <StyledInformationContainer>
-        <StyledUserIconContainer>
-          <ProfileSvg imageUrl={Dummy.image} />
-          {activeEditMode && (
-            <StyledSettingButton>
-              <IcSettingLine color={theme.color.buttonNormal} size="1rem" />
-            </StyledSettingButton>
-          )}
-        </StyledUserIconContainer>
-        <StyledUserNickname>{Dummy.name}</StyledUserNickname>
-        <StyledUserMail>{Dummy.mail}</StyledUserMail>
-      </StyledInformationContainer>
-      {activeEditMode ? (
+      {currentUser && (
         <>
-          <SimpleTextField
-            fieldLabel="닉네임"
-            placeholder="뿌슝이"
-            width="100%"
-            onClickClearButton={() => setNickname('')}
-            value={nickname}
-            onChange={handleInputChange}
-          />
-          <StyledButtonContainer>
-            <BoxButton size="medium" variant="filled" rounding={4} width="100%">
-              저장
-            </BoxButton>
+          <StyledInformationContainer>
+            <StyledUserIconContainer>
+              <ProfileSvg imageUrl={currentUser.profileImage.midUrl} />
+              {activeEditMode && (
+                <StyledSettingButton>
+                  <IcSettingLine color={theme.color.buttonNormal} size="1rem" />
+                </StyledSettingButton>
+              )}
+            </StyledUserIconContainer>
+            <StyledUserNickname>{currentUser.nickName}</StyledUserNickname>
+            <StyledUserMail>{currentUser.email}</StyledUserMail>
+          </StyledInformationContainer>
+          {/* {activeEditMode ? (
+            <>
+              <SimpleTextField
+                fieldLabel="닉네임"
+                placeholder="뿌슝이"
+                width="100%"
+                onClickClearButton={() => setNickname('')}
+                value={nickname}
+                onChange={handleInputChange}
+              />
+              <StyledButtonContainer>
+                <BoxButton size="medium" variant="filled" rounding={4} width="100%">
+                  저장
+                </BoxButton>
+                <BoxButton
+                  size="medium"
+                  variant="line"
+                  rounding={4}
+                  width="100%"
+                  onClick={() => setAcitveEditMode(false)}
+                >
+                  취소
+                </BoxButton>
+              </StyledButtonContainer>
+            </>
+          ) : (
             <BoxButton
               size="medium"
               variant="line"
               rounding={4}
               width="100%"
-              onClick={() => setAcitveEditMode(false)}
+              onClick={() => {
+                setAcitveEditMode(true);
+                setNickname(currentUser.nickName);
+              }}
             >
-              취소
+              프로필 편집
             </BoxButton>
-          </StyledButtonContainer>
+          )} */}
         </>
-      ) : (
-        <BoxButton
-          size="medium"
-          variant="line"
-          rounding={4}
-          width="100%"
-          onClick={() => {
-            setAcitveEditMode(true);
-            setNickname(Dummy.name);
-          }}
-        >
-          프로필 편집
-        </BoxButton>
       )}
     </StyledContainer>
   );

--- a/src/home/components/UserInformationCard/UserInformationCard.tsx
+++ b/src/home/components/UserInformationCard/UserInformationCard.tsx
@@ -1,16 +1,17 @@
-import { useState } from 'react';
+// TODO: 프로필 편집 관련 코드 임시 주석 처리
+// import { useState } from 'react';
 
-import { BoxButton, IcSettingLine, SimpleTextField } from '@yourssu/design-system-react';
-import { useTheme } from 'styled-components';
+// import { BoxButton, SimpleTextField, IcSettingLine } from '@yourssu/design-system-react';
+// import { useTheme } from 'styled-components';
 
 import { ProfileSvg } from '@/components/ProfileSvg/ProfileSVG';
 import { useGetUserData } from '@/home/hooks/useGetUserData';
 
 import {
-  StyledButtonContainer,
+  // StyledButtonContainer,
   StyledContainer,
   StyledInformationContainer,
-  StyledSettingButton,
+  // StyledSettingButton,
   StyledUserIconContainer,
   StyledUserMail,
   StyledUserNickname,
@@ -18,13 +19,13 @@ import {
 
 export const UserInformationCard = () => {
   const { data: currentUser } = useGetUserData();
-  const [activeEditMode, setAcitveEditMode] = useState(false);
-  const [nickname, setNickname] = useState<string>('');
-  const theme = useTheme();
+  // const [activeEditMode, setAcitveEditMode] = useState(false);
+  // const [nickname, setNickname] = useState<string>('');
+  // const theme = useTheme();
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setNickname(event.target.value);
-  };
+  // const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   setNickname(event.target.value);
+  // };
 
   return (
     <StyledContainer>
@@ -33,11 +34,11 @@ export const UserInformationCard = () => {
           <StyledInformationContainer>
             <StyledUserIconContainer>
               <ProfileSvg imageUrl={currentUser.profileImage.midUrl} />
-              {activeEditMode && (
+              {/* {activeEditMode && (
                 <StyledSettingButton>
                   <IcSettingLine color={theme.color.buttonNormal} size="1rem" />
                 </StyledSettingButton>
-              )}
+              )} */}
             </StyledUserIconContainer>
             <StyledUserNickname>{currentUser.nickName}</StyledUserNickname>
             <StyledUserMail>{currentUser.email}</StyledUserMail>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #231

### 기존 코드에 영향을 미치지 않는 변경사항

김뿌슝씨를 쫓아냈습니다

![image](https://github.com/yourssu/Soomsil-Web/assets/87255462/e937690a-8b87-4113-a547-24e81a8a06eb)

스웨거로 imagePK 확인하다가 갈매기 사진으로 바뀌었는데 일단 사용자는 프로필 변경 못 하게 해뒀으니 신경쓰지 마세요..!

## 2️⃣ 알아두시면 좋아요!

- 스웨거에 프로필 수정 api가 존재하는데 여기서 작업 안 한 이유

  프로필 이미지 / 닉네임 수정 API가 별도로 존재하는 게 아니라 하나만 있는데요,
  제가 알기론 사용자가 이미지 파일을 직접 업로드 하는 게 아니라 번호만 고르는 식인 걸로 알거든요..?
  (뿌슝이 이미지 N개 중 사용자가 선택 -> 그 번호를 imagePK에 넣음 -> 서버에서 imagePK에 맞는 뿌슝이 이미지를 프로필로 설정)

  근데 지금 뿌슝이 이미지가 준비된 상태도 아니고, 어떻게 선택하게 할지에 대한 뷰도 없어서
  일단 프로필 편집 버튼을 전부 주석처리 해뒀습니다 (혹시 제가 잘못 알고있는 거면 알려주세요)

  홈 TF 채널에 프로필 이미지 관련 스레드가 있었는데 기간 지나서 안 보여요 흑흑 한번 더 물어보겠습니당...
  어쨌든 김뿌슝씨 그대로 두긴 좀 그래서 일단 올립니다
  
  ![image](https://github.com/yourssu/Soomsil-Web/assets/87255462/08bbbdd0-6d1b-44b1-8526-b33f6dd22f18)


## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
