### PR TITLE
feat: 서랍장 배너 API 연결

### DIFF
--- a/src/drawer/apis/getDrawerBanner.ts
+++ b/src/drawer/apis/getDrawerBanner.ts
@@ -1,0 +1,8 @@
+import { soomsilClient } from '@/apis';
+
+import { DrawerBannerResponse } from '../types/banner.type';
+
+export const getDrawerBanner = async (): Promise<DrawerBannerResponse> => {
+  const { data } = await soomsilClient.get('/v2/drawer/banner');
+  return data;
+};

--- a/src/drawer/hooks/useGetDrawerBanner.ts
+++ b/src/drawer/hooks/useGetDrawerBanner.ts
@@ -1,9 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getDrawerBanner } from '../apis/getDrawerBanner';
 
 export const useGetDrawerBanner = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['drawerBanner'],
     queryFn: getDrawerBanner,
     staleTime: Infinity,

--- a/src/drawer/hooks/useGetDrawerBanner.ts
+++ b/src/drawer/hooks/useGetDrawerBanner.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getDrawerBanner } from '../apis/getDrawerBanner';
+
+export const useGetDrawerBanner = () => {
+  return useQuery({
+    queryKey: ['drawerBanner'],
+    queryFn: getDrawerBanner,
+    staleTime: Infinity,
+    select: (data) => data.bannerList,
+  });
+};

--- a/src/drawer/hooks/useGetNewRelease.ts
+++ b/src/drawer/hooks/useGetNewRelease.ts
@@ -1,4 +1,4 @@
-import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+import { InfiniteData, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getNewRelease } from '@/drawer/apis/getNewRelease';
 
@@ -9,7 +9,7 @@ import { ProductResponses, ProductResult } from '../types/product.type';
 type ProductRequestParamsWithoutPage = Omit<ProductRequestParams, 'page'>;
 
 export const useGetNewRelease = ({ responseType, category }: ProductRequestParamsWithoutPage) => {
-  return useInfiniteQuery<
+  return useSuspenseInfiniteQuery<
     ProductResponses[],
     Error,
     InfiniteData<ProductResult[], number>,

--- a/src/drawer/hooks/useGetStarRank.ts
+++ b/src/drawer/hooks/useGetStarRank.ts
@@ -1,4 +1,4 @@
-import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+import { InfiniteData, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getRanking } from '../apis/getRanking';
 import { PRODUCTS_PER_PAGE } from '../constants/page.constant';
@@ -8,7 +8,7 @@ import { ProductResponses, ProductResult } from '../types/product.type';
 type ProductRequestParamsWithoutPage = Omit<ProductRequestParams, 'page'>;
 
 export const useGetStarRank = ({ responseType, category }: ProductRequestParamsWithoutPage) => {
-  return useInfiniteQuery<
+  return useSuspenseInfiniteQuery<
     ProductResponses[],
     Error,
     InfiniteData<ProductResult[], number>,

--- a/src/drawer/pages/Ranking/BannerSection.tsx
+++ b/src/drawer/pages/Ranking/BannerSection.tsx
@@ -6,12 +6,12 @@ export const BannerSection = () => {
   const { data: bannerList } = useGetDrawerBanner();
 
   return (
-    <section>
+    <>
       {bannerList.slice(0, 2).map((banner) => (
         <a href={banner.website} key={banner.id} target="_blank">
           <StyledImage src={banner.image} alt={banner.name} />
         </a>
       ))}
-    </section>
+    </>
   );
 };

--- a/src/drawer/pages/Ranking/BannerSection.tsx
+++ b/src/drawer/pages/Ranking/BannerSection.tsx
@@ -1,0 +1,17 @@
+import { useGetDrawerBanner } from '@/drawer/hooks/useGetDrawerBanner';
+
+import { StyledImage } from './Ranking.style';
+
+export const BannerSection = () => {
+  const { data: bannerList } = useGetDrawerBanner();
+
+  return (
+    <section>
+      {bannerList.slice(0, 2).map((banner) => (
+        <a href={banner.website} key={banner.id} target="_blank">
+          <StyledImage src={banner.image} alt={banner.name} />
+        </a>
+      ))}
+    </section>
+  );
+};

--- a/src/drawer/pages/Ranking/NewReleaseSection.tsx
+++ b/src/drawer/pages/Ranking/NewReleaseSection.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { BigDrawerCard } from '@/drawer/components/DrawerCard/BigDrawerCard';
+import { GrayButton } from '@/drawer/components/GrayButton/GrayButton';
+import { useGetNewRelease } from '@/drawer/hooks/useGetNewRelease';
+import { CategoryState } from '@/drawer/recoil/CategoryState';
+
+import {
+  StyledBetweenContainer,
+  StyledCardContainer,
+  StyledDescription,
+  StyledTextContainer,
+  StyledTitle,
+} from './Ranking.style';
+
+export const NewReleaseSection = () => {
+  const navigate = useNavigate();
+  const selectedCategory = useRecoilValue(CategoryState);
+
+  const { data: newReleases } = useGetNewRelease({
+    responseType: 'WEB',
+    category: selectedCategory,
+  });
+
+  return (
+    <div>
+      <StyledBetweenContainer>
+        <StyledTextContainer>
+          <StyledTitle>New Releases</StyledTitle>
+          <StyledDescription>새로 출시된 서비스를 확인해보세요.</StyledDescription>
+        </StyledTextContainer>
+        <GrayButton
+          text={'더보기'}
+          onClick={() => {
+            navigate('/drawer/newRelease');
+          }}
+        />
+      </StyledBetweenContainer>
+      <StyledCardContainer>
+        {newReleases.pages[0].slice(0, 3).map((product) => (
+          <BigDrawerCard
+            key={product.productNo}
+            link={`/drawer/services/${product.productNo}`}
+            title={product.productTitle}
+            body={product.productSubTitle}
+            bookmarkCount={product.count}
+            isBookmarked={product.isBookmarked}
+            bigImgSrc={product.introductionImage[0]}
+            smallImgSrc={product.mainImage}
+          />
+        ))}
+      </StyledCardContainer>
+    </div>
+  );
+};

--- a/src/drawer/pages/Ranking/Ranking.style.ts
+++ b/src/drawer/pages/Ranking/Ranking.style.ts
@@ -39,7 +39,7 @@ export const StyledBetweenContainer = styled.div`
 `;
 
 export const StyledImage = styled.img`
-  width: auto;
+  width: 100%;
   height: 22.125rem;
   border-radius: 0.5rem;
   object-fit: cover;

--- a/src/drawer/pages/Ranking/Ranking.tsx
+++ b/src/drawer/pages/Ranking/Ranking.tsx
@@ -9,6 +9,7 @@ import { DetectClick } from '@/drawer/components/DetectClick/DetectClick';
 import { BigDrawerCard } from '@/drawer/components/DrawerCard/BigDrawerCard';
 import { GrayButton } from '@/drawer/components/GrayButton/GrayButton';
 import { SMALL_DESKTOP_MEDIA_QUERY } from '@/drawer/constants/mobileview.constant';
+import { useGetDrawerBanner } from '@/drawer/hooks/useGetDrawerBanner';
 import { useGetNewRelease } from '@/drawer/hooks/useGetNewRelease';
 import { useGetStarRank } from '@/drawer/hooks/useGetStarRank';
 import { CategoryState } from '@/drawer/recoil/CategoryState';
@@ -28,6 +29,9 @@ import {
 export const Ranking = () => {
   const navigate = useNavigate();
   const [selectedCategory, setSelectedCategory] = useRecoilState(CategoryState);
+
+  const { data: bannerList } = useGetDrawerBanner();
+
   const { data: newReleases } = useGetNewRelease({
     responseType: 'WEB',
     category: selectedCategory,
@@ -78,14 +82,12 @@ export const Ranking = () => {
               ))}
           </StyledCardContainer>
         </div>
-        <StyledImage
-          src="https://yourssu-post-attachments-stg.s3.ap-northeast-2.amazonaws.com/soomsil.jpeg"
-          alt="drawer main image1"
-        />
-        <StyledImage
-          src="https://yourssu-post-attachments-stg.s3.ap-northeast-2.amazonaws.com/animalssu.jpeg"
-          alt="drawer main image2"
-        />
+        {bannerList &&
+          bannerList.slice(0, 2).map((banner) => (
+            <a href={banner.website} key={banner.id} target="_blank">
+              <StyledImage src={banner.image} alt={banner.name} />
+            </a>
+          ))}
         <div>
           <StyledBetweenContainer>
             <StyledTextContainer>

--- a/src/drawer/pages/Ranking/Ranking.tsx
+++ b/src/drawer/pages/Ranking/Ranking.tsx
@@ -1,45 +1,21 @@
 import { useEffect } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 import { CategoryDropdownMenu } from '@/drawer/components/Category/CategoryDropdownMenu/CategoryDropdownMenu';
 import { RankingCategory } from '@/drawer/components/Category/RankingCategory';
-import { DetectClick } from '@/drawer/components/DetectClick/DetectClick';
-import { BigDrawerCard } from '@/drawer/components/DrawerCard/BigDrawerCard';
-import { GrayButton } from '@/drawer/components/GrayButton/GrayButton';
 import { SMALL_DESKTOP_MEDIA_QUERY } from '@/drawer/constants/mobileview.constant';
-import { useGetDrawerBanner } from '@/drawer/hooks/useGetDrawerBanner';
-import { useGetNewRelease } from '@/drawer/hooks/useGetNewRelease';
-import { useGetStarRank } from '@/drawer/hooks/useGetStarRank';
 import { CategoryState } from '@/drawer/recoil/CategoryState';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 
-import {
-  StyledBetweenContainer,
-  StyledCardContainer,
-  StyledContainer,
-  StyledDescription,
-  StyledImage,
-  StyledRankingContainer,
-  StyledTextContainer,
-  StyledTitle,
-} from './Ranking.style';
+import { BannerSection } from './BannerSection';
+import { NewReleaseSection } from './NewReleaseSection';
+import { StyledContainer, StyledRankingContainer } from './Ranking.style';
+import { RankingSection } from './RankingSection';
 
 export const Ranking = () => {
-  const navigate = useNavigate();
-  const [selectedCategory, setSelectedCategory] = useRecoilState(CategoryState);
+  const setSelectedCategory = useSetRecoilState(CategoryState);
 
-  const { data: bannerList } = useGetDrawerBanner();
-
-  const { data: newReleases } = useGetNewRelease({
-    responseType: 'WEB',
-    category: selectedCategory,
-  });
-  const { data: rankings } = useGetStarRank({
-    responseType: 'WEB',
-    category: selectedCategory,
-  });
   const isSmallDesktop = useMediaQuery(SMALL_DESKTOP_MEDIA_QUERY);
 
   useEffect(() => {
@@ -52,73 +28,10 @@ export const Ranking = () => {
       <StyledRankingContainer $isSmallDesktop={isSmallDesktop}>
         <div>
           {isSmallDesktop && <CategoryDropdownMenu />}
-          <StyledBetweenContainer>
-            <StyledTextContainer>
-              <StyledTitle>Star Ranking</StyledTitle>
-              <StyledDescription>실시간 랭킹을 확인해보세요.</StyledDescription>
-            </StyledTextContainer>
-            <GrayButton
-              text={'더보기'}
-              onClick={() => {
-                navigate('/drawer/starRanking');
-              }}
-            />
-          </StyledBetweenContainer>
-          <StyledCardContainer>
-            {rankings &&
-              rankings.pages[0].slice(0, 3).map((product) => (
-                <DetectClick key={product.productNo} product={product}>
-                  <BigDrawerCard
-                    link={`/drawer/services/${product.productNo}`}
-                    title={product.productTitle}
-                    body={product.productSubTitle}
-                    bookmarkCount={product.count}
-                    isBookmarked={product.isBookmarked}
-                    bigImgSrc={product.introductionImage[0]}
-                    smallImgSrc={product.mainImage}
-                    onClick={() => {}}
-                  />
-                </DetectClick>
-              ))}
-          </StyledCardContainer>
+          <RankingSection />
         </div>
-        {bannerList &&
-          bannerList.slice(0, 2).map((banner) => (
-            <a href={banner.website} key={banner.id} target="_blank">
-              <StyledImage src={banner.image} alt={banner.name} />
-            </a>
-          ))}
-        <div>
-          <StyledBetweenContainer>
-            <StyledTextContainer>
-              <StyledTitle>New Releases</StyledTitle>
-              <StyledDescription>새로 출시된 서비스를 확인해보세요.</StyledDescription>
-            </StyledTextContainer>
-            <GrayButton
-              text={'더보기'}
-              onClick={() => {
-                navigate('/drawer/newRelease');
-              }}
-            />
-          </StyledBetweenContainer>
-          <StyledCardContainer>
-            {newReleases &&
-              newReleases.pages[0].slice(0, 3).map((product) => (
-                <DetectClick key={product.productNo} product={product}>
-                  <BigDrawerCard
-                    key={product.productNo}
-                    link={`/drawer/services/${product.productNo}`}
-                    title={product.productTitle}
-                    body={product.productSubTitle}
-                    bookmarkCount={product.count}
-                    isBookmarked={product.isBookmarked}
-                    bigImgSrc={product.introductionImage[0]}
-                    smallImgSrc={product.mainImage}
-                  />
-                </DetectClick>
-              ))}
-          </StyledCardContainer>
-        </div>
+        <BannerSection />
+        <NewReleaseSection />
       </StyledRankingContainer>
     </StyledContainer>
   );

--- a/src/drawer/pages/Ranking/RankingSection.tsx
+++ b/src/drawer/pages/Ranking/RankingSection.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { BigDrawerCard } from '@/drawer/components/DrawerCard/BigDrawerCard';
+import { GrayButton } from '@/drawer/components/GrayButton/GrayButton';
+import { useGetStarRank } from '@/drawer/hooks/useGetStarRank';
+import { CategoryState } from '@/drawer/recoil/CategoryState';
+
+import {
+  StyledBetweenContainer,
+  StyledCardContainer,
+  StyledDescription,
+  StyledTextContainer,
+  StyledTitle,
+} from './Ranking.style';
+
+export const RankingSection = () => {
+  const navigate = useNavigate();
+  const selectedCategory = useRecoilValue(CategoryState);
+
+  const { data: rankings } = useGetStarRank({
+    responseType: 'WEB',
+    category: selectedCategory,
+  });
+
+  return (
+    <>
+      <StyledBetweenContainer>
+        <StyledTextContainer>
+          <StyledTitle>Star Ranking</StyledTitle>
+          <StyledDescription>실시간 랭킹을 확인해보세요.</StyledDescription>
+        </StyledTextContainer>
+        <GrayButton
+          text={'더보기'}
+          onClick={() => {
+            navigate('/drawer/starRanking');
+          }}
+        />
+      </StyledBetweenContainer>
+      <StyledCardContainer>
+        {rankings.pages[0].slice(0, 3).map((product) => (
+          <BigDrawerCard
+            key={product.productNo}
+            link={`/drawer/services/${product.productNo}`}
+            title={product.productTitle}
+            body={product.productSubTitle}
+            bookmarkCount={product.count}
+            isBookmarked={product.isBookmarked}
+            bigImgSrc={product.introductionImage[0]}
+            smallImgSrc={product.mainImage}
+          />
+        ))}
+      </StyledCardContainer>
+    </>
+  );
+};

--- a/src/drawer/types/banner.type.ts
+++ b/src/drawer/types/banner.type.ts
@@ -1,0 +1,11 @@
+interface Banner {
+  id: number;
+  image: string;
+  name: string;
+  type: 'WEB' | 'APP' | 'WEBAPP';
+  website: string;
+}
+
+export interface DrawerBannerResponse {
+  bannerList: Banner[];
+}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #234 

<img width="1316" alt="image" src="https://github.com/yourssu/Soomsil-Web/assets/76615094/a6de9e45-a000-4d03-a3a5-d121440875ba">


### 기존 코드에 영향을 미치지 않는 변경사항
- `drawer/hooks/useGetDrawerBanner.ts`
  - 배너 API에 요청을 보내 배너 리스트를 가져오는 쿼리입니다.

### 기존 코드에 영향을 미치는 변경사항
- `drawer/pages/Ranking/Ranking.tsx`
  - 랭킹 페이지에서 `useGetDrawerBanner()` 쿼리를 호출하여 배너를 가져와 화면에 보여줍니다.

### 버그 픽스

## 2️⃣ 알아두시면 좋아요!
  - 배너는 변경이 자주 일어나지 않는 데이터이기 때문에 페이지 새로고침이 이루어지지 않으면 캐시에서 배너 데이터를 가져와 보여줄 수 있도록 `useGetDrawerBanner`의 쿼리의 `staleTime`을 `Infinity`로 설정하였습니다.

## 3️⃣ 추후 작업
- 리뷰 기반 수정

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
