### PR TITLE
feat: 서랍장 서비스 수정 페이지 제작 및 관련 자잘한 업데이트

### DIFF
--- a/src/drawer/apis/putUpdateProduct.ts
+++ b/src/drawer/apis/putUpdateProduct.ts
@@ -1,0 +1,27 @@
+import { soomsilClient } from '@/apis';
+
+import { RegisterFormValues } from '../types/form.type';
+import { ImageResult } from '../types/image.type';
+
+const renameImageKeys = (image: ImageResult) => {
+  return {
+    key: image.imageKey,
+    url: image.imageUrl,
+  };
+};
+
+export const putUpdateProduct = async (
+  productNo: number,
+  product: RegisterFormValues,
+  images: ImageResult[]
+) => {
+  const [thumbnailImage, ...introductionImages] = images;
+
+  const response = await soomsilClient.put(`/v2/drawer/${productNo}`, {
+    ...product,
+    thumbnailImage: renameImageKeys(thumbnailImage),
+    introductionImages: introductionImages.map(renameImageKeys),
+  });
+
+  return response.data;
+};

--- a/src/drawer/components/DrawerCard/CardSettingDropdownMenu/CardSettingDropdownMenu.style.ts
+++ b/src/drawer/components/DrawerCard/CardSettingDropdownMenu/CardSettingDropdownMenu.style.ts
@@ -13,6 +13,7 @@ export const StyledSettingDropdownContent = styled(DropdownMenu.Content)`
   border: 1px solid ${({ theme }) => theme.color.borderThin};
   border-radius: 0.25rem;
   box-shadow: 0px 1px 3px 0px rgba(107, 114, 128, 0.4);
+  background-color: ${({ theme }) => theme.color.bgNormal};
 `;
 
 export const StyledSettingDropdownItem = styled(DropdownMenu.Item)`

--- a/src/drawer/components/DrawerCard/CardSettingDropdownMenu/CardSettingDropdownMenu.tsx
+++ b/src/drawer/components/DrawerCard/CardSettingDropdownMenu/CardSettingDropdownMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from './CardSettingDropdownMenu.style';
 
 interface CardSettingDropdownMenuProps {
+  productNo: number;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onClickRemoveButton: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -14,6 +15,7 @@ interface CardSettingDropdownMenuProps {
 }
 
 export const CardSettingDropdownMenu = ({
+  productNo,
   open,
   onOpenChange,
   onClickRemoveButton,
@@ -25,7 +27,10 @@ export const CardSettingDropdownMenu = ({
       <DropdownMenu.Portal>
         <StyledSettingDropdownContent align="end">
           <StyledSettingDropdownItem asChild>
-            <Link to="/drawer/register" onClick={(event) => event.stopPropagation()}>
+            <Link
+              to={`/drawer/services/${productNo}/edit`}
+              onClick={(event) => event.stopPropagation()}
+            >
               서비스 수정
             </Link>
           </StyledSettingDropdownItem>

--- a/src/drawer/components/DrawerCard/UserDrawerCard/UserDrawerCard.tsx
+++ b/src/drawer/components/DrawerCard/UserDrawerCard/UserDrawerCard.tsx
@@ -48,6 +48,7 @@ export const UserDrawerCard = ({
           isBookmarked={isBookmarked}
         />
         <CardSettingDropdownMenu
+          productNo={productNo}
           open={isCardSettingClicked}
           onOpenChange={setIsCardSettingClicked}
           onClickRemoveButton={handleClickRemoveButton}

--- a/src/drawer/components/Input/Input.tsx
+++ b/src/drawer/components/Input/Input.tsx
@@ -17,17 +17,22 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   description: string;
   validate?: (value: string) => boolean;
   name: string;
+  defaultValue?: string;
 }
 
-export const Input = ({ title, description, validate, name, required, ...props }: InputProps) => {
-  const { register, formState, getValues } = useFormContext();
+export const Input = ({
+  title,
+  description,
+  validate,
+  name,
+  required,
+  defaultValue = '',
+  ...props
+}: InputProps) => {
+  const { register, formState, getValues, watch } = useFormContext();
 
-  const [inputValue, setInputValue] = useState('');
+  const inputValue = watch(name, defaultValue);
   const [isWarned, setIsWarned] = useState(false);
-
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value);
-  };
 
   const checkValid = useMemo(() => {
     if (validate && validate(inputValue) && inputValue.length > 0) {
@@ -44,9 +49,8 @@ export const Input = ({ title, description, validate, name, required, ...props }
   }, [inputValue, props.maxLength, validate]);
 
   useEffect(() => {
-    const value = getValues(name);
-    if (formState.isSubmitted && !value && required) setIsWarned(true);
-  }, [formState, getValues, name, required]);
+    if (formState.isSubmitted && !inputValue && required) setIsWarned(true);
+  }, [formState, inputValue, name, required]);
 
   return (
     <StyledContainer>
@@ -64,13 +68,10 @@ export const Input = ({ title, description, validate, name, required, ...props }
               const { appStoreUrl, githubUrl, googlePlayUrl, webpageUrl } = getValues();
               if (appStoreUrl || githubUrl || googlePlayUrl || webpageUrl)
                 if (value === '') return true;
-
               return validate ? !validate(value) : true;
             },
           })}
           id={title}
-          value={inputValue}
-          onChange={handleInputChange}
           $isWarned={isWarned}
           $hasText={inputValue.length > 0}
           {...props}

--- a/src/drawer/components/OverviewImage/OverviewImage.tsx
+++ b/src/drawer/components/OverviewImage/OverviewImage.tsx
@@ -14,25 +14,22 @@ import {
 } from './OverviewImage.style';
 
 export const OverviewImage = () => {
-  const { register, formState, setValue } = useFormContext();
+  const { register, formState, getValues, setValue, watch } = useFormContext();
+  const formFiles: File[] = watch('introductionImages');
 
-  const [files, setFiles] = useState<File[]>([]);
   const [isWarned, setIsWarned] = useState(false);
-
   const multiFileRef = useRef<HTMLInputElement | null>(null);
 
   const MAX_FILE_COUNT = 5;
 
   const handleFileChange = (file: File | undefined, index: number) => {
-    setFiles((prevFiles) => {
-      const newFiles = [...prevFiles];
-      if (file && ALLOWED_IMAGE_TYPE.includes(file.type)) {
-        newFiles[index] = file;
-      } else {
-        alert('이미지 포맷은 jpg, jpeg, png, gif 중 하나여야 합니다.');
-      }
-      return newFiles;
-    });
+    const newFiles = [...getValues('introductionImages')];
+    if (file && ALLOWED_IMAGE_TYPE.includes(file.type)) {
+      newFiles[index] = file;
+    } else {
+      alert('이미지 포맷은 jpg, jpeg, png, gif 중 하나여야 합니다.');
+    }
+    setValue('introductionImages', newFiles);
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
@@ -43,24 +40,21 @@ export const OverviewImage = () => {
   };
 
   const handleDeleteFile = (index: number) => {
-    setFiles((prevFiles) => {
-      const newFiles = prevFiles.filter((_, i) => i !== index);
-      return newFiles;
-    });
+    const prevFiles = getValues('introductionImages');
+    const newFiles = [...prevFiles].filter((_, i) => i !== index);
+    setValue('introductionImages', newFiles);
   };
 
   useEffect(() => {
-    if (formState.isSubmitted && files.length === 0) setIsWarned(true);
-    if (files.length) setIsWarned(false);
-  }, [files, formState]);
+    if (formState.isSubmitted && formFiles.length === 0) setIsWarned(true);
+    if (formFiles.length) setIsWarned(false);
+  }, [formFiles, formState]);
 
   useEffect(() => {
     const dataTransfer = new DataTransfer();
-    files.forEach((file) => dataTransfer.items.add(file));
+    formFiles.forEach((file) => dataTransfer.items.add(file));
     multiFileRef.current!.files = dataTransfer.files;
-
-    setValue('introductionImages', files);
-  }, [files, setValue]);
+  }, [formFiles]);
 
   return (
     <StyledOverviewContainer>
@@ -77,7 +71,7 @@ export const OverviewImage = () => {
           hidden
         />
         {Array.from({ length: MAX_FILE_COUNT }).map((_, index) => {
-          const file = files[index];
+          const file = formFiles[index];
           const key = file ? `file-${file.name}-${file.lastModified}` : `file-empty-${index}`;
           return (
             <OverviewFileUpload

--- a/src/drawer/components/TextArea/TextArea.tsx
+++ b/src/drawer/components/TextArea/TextArea.tsx
@@ -19,20 +19,14 @@ interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 }
 
 export const TextArea = ({ title, description, name, ...props }: TextAreaProps) => {
-  const { register, formState, getValues } = useFormContext();
+  const { register, formState, watch } = useFormContext();
 
-  const [textAreaValue, setTextAreaValue] = useState('');
+  const textAreaValue = watch(name, '');
   const [isWarned, setIsWarned] = useState(false);
 
-  const handleTextAreaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setIsWarned(false);
-    setTextAreaValue(event.target.value);
-  };
-
   useEffect(() => {
-    const value = getValues(name);
-    if (formState.isSubmitted && !value) setIsWarned(true);
-  }, [formState, getValues, name]);
+    if (formState.isSubmitted && !textAreaValue) setIsWarned(true);
+  }, [formState, textAreaValue]);
 
   return (
     <StyledContainer>
@@ -44,10 +38,13 @@ export const TextArea = ({ title, description, name, ...props }: TextAreaProps) 
       </StyledLabelContainer>
       <StyledTextAreaContainer>
         <StyledTextArea
-          {...register(name, { required: props.required })}
+          {...register(name, {
+            required: props.required,
+            onChange: () => {
+              setIsWarned(false);
+            },
+          })}
           id={title}
-          value={textAreaValue}
-          onChange={handleTextAreaChange}
           rows={8}
           $isWarned={isWarned}
           $hasText={textAreaValue.length > 0}

--- a/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
+++ b/src/drawer/components/ThumbnailInput/ThumbnailInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { IcPlusLine, IconContext } from '@yourssu/design-system-react';
 import { useFormContext } from 'react-hook-form';
@@ -20,10 +20,11 @@ interface StyledThumbnailProps {
 }
 
 export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
-  const { register, formState, getValues, setValue } = useFormContext();
-  const { onChange, ref } = register(name, { required: true });
+  const { register, formState, setValue, watch } = useFormContext();
 
-  const [postImg, setPostImg] = useState<File | null>();
+  const thumbnailFile: File[] = watch(name);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const [isPreview, setIsPreview] = useState<string | null>('');
   const [isWarned, setIsWarned] = useState<boolean>(false);
 
@@ -33,32 +34,39 @@ export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
     if (event.target.files !== null) {
       const file = event.target.files[0];
       if (file && ALLOWED_IMAGE_TYPE.includes(file.type)) {
-        setPostImg(file);
+        setValue(name, [file]);
       } else {
         alert('이미지 포맷은 jpg, jpeg, png, gif 중 하나여야 합니다.');
-        setValue(name, null);
-        setPostImg(null);
+        setValue(name, []);
       }
     }
   };
 
   useEffect(() => {
-    if (postImg) {
+    if (thumbnailFile[0]) {
       const reader = new FileReader();
       reader.onloadend = () => {
         setIsPreview(reader.result as string);
       };
-      reader.readAsDataURL(postImg);
+      reader.readAsDataURL(thumbnailFile[0]);
       setIsWarned(false);
     } else {
       setIsPreview(null);
     }
-  }, [postImg]);
+  }, [thumbnailFile]);
 
   useEffect(() => {
-    const value = getValues(name);
-    if (formState.isSubmitted && !value.length) setIsWarned(true);
-  }, [formState, getValues, name]);
+    if (!inputRef.current) return;
+    if (!thumbnailFile.length) return;
+
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(thumbnailFile[0]);
+    inputRef.current.files = dataTransfer.files;
+  }, [thumbnailFile, inputRef]);
+
+  useEffect(() => {
+    if (formState.isSubmitted && !thumbnailFile.length) setIsWarned(true);
+  }, [formState, thumbnailFile]);
 
   return (
     <StyledThumbnailContainer>
@@ -67,15 +75,16 @@ export const ThumbnailInput = ({ name }: StyledThumbnailProps) => {
         <StyledThumbnailDescription>(권장 : 1024px X 1024px)</StyledThumbnailDescription>
       </StyledThumbnailTitleContainer>
       <input
+        {...register(name, {
+          required: true,
+          onChange: (e) => {
+            handleChangeImg(e);
+          },
+        })}
+        ref={inputRef}
         id="inputFile"
         type="file"
         accept=".jpg, .jpeg, .png, .gif"
-        onChange={(event) => {
-          handleChangeImg(event);
-          onChange(event);
-        }}
-        name={name}
-        ref={ref}
         style={{ display: 'none' }}
       />
       <StyledThumbnailNone htmlFor="inputFile">

--- a/src/drawer/constants/registerFormDefaultValue.constant.ts
+++ b/src/drawer/constants/registerFormDefaultValue.constant.ts
@@ -1,0 +1,14 @@
+import { RegisterFormValues } from '@/drawer/types/form.type';
+
+export const registerFormDefaultValue: RegisterFormValues = {
+  title: '',
+  subtitle: '',
+  content: '',
+  category: '',
+  webpageUrl: '',
+  googlePlayUrl: '',
+  appStoreUrl: '',
+  githubUrl: '',
+  thumbnailImage: [],
+  introductionImages: [],
+};

--- a/src/drawer/hooks/usePutUpdateProduct.ts
+++ b/src/drawer/hooks/usePutUpdateProduct.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { postImages } from '../apis/postImages';
+import { putUpdateProduct } from '../apis/putUpdateProduct';
+import { RegisterFormValues } from '../types/form.type';
+
+export const usePutUpdateProduct = (productNo: number) => {
+  return useMutation({
+    mutationFn: async (data: RegisterFormValues) => {
+      const imageList = [...data.thumbnailImage, ...data.introductionImages] as File[];
+      const images = await postImages(imageList);
+
+      const response = await putUpdateProduct(productNo, data, images);
+      return response;
+    },
+  });
+};

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 
 import { BoxButton } from '@yourssu/design-system-react';
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 
 import { Loading } from '@/components/Loading/Loading';
 import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
@@ -25,7 +24,6 @@ import {
 } from './Register.style';
 
 export const Register = () => {
-  const navigate = useNavigate();
   const methods = useForm<RegisterFormValues>({ defaultValues: registerFormDefaultValue });
 
   const [linkExist, setLinkExist] = useState(true);
@@ -52,13 +50,6 @@ export const Register = () => {
       }
     }
   }, [methods.formState]);
-
-  useEffect(() => {
-    if (registerProductMutation.isSuccess) {
-      alert('서비스가 등록되었습니다.');
-      navigate('/drawer/myDrawers?tab=MYDRAWER');
-    }
-  }, [registerProductMutation.isSuccess, navigate]);
 
   return (
     <FormProvider {...methods}>

--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { BoxButton } from '@yourssu/design-system-react';
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 import { Loading } from '@/components/Loading/Loading';
 import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
@@ -12,6 +13,7 @@ import { ThumbnailInput } from '@/drawer/components/ThumbnailInput/ThumbnailInpu
 import { WarningBox } from '@/drawer/components/WarningBox/WarningBox';
 import { LINK, REGISTER_URL } from '@/drawer/constants/link.constant';
 import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
+import { registerFormDefaultValue } from '@/drawer/constants/registerFormDefaultValue.constant';
 import { usePostProduct } from '@/drawer/hooks/usePostProduct';
 import { RegisterFormValues } from '@/drawer/types/form.type';
 
@@ -23,7 +25,8 @@ import {
 } from './Register.style';
 
 export const Register = () => {
-  const methods = useForm<RegisterFormValues>();
+  const navigate = useNavigate();
+  const methods = useForm<RegisterFormValues>({ defaultValues: registerFormDefaultValue });
 
   const [linkExist, setLinkExist] = useState(true);
   const [isChecked, setIsChecked] = useState(false);
@@ -49,6 +52,13 @@ export const Register = () => {
       }
     }
   }, [methods.formState]);
+
+  useEffect(() => {
+    if (registerProductMutation.isSuccess) {
+      alert('서비스가 등록되었습니다.');
+      navigate('/drawer/myDrawers?tab=MYDRAWER');
+    }
+  }, [registerProductMutation.isSuccess, navigate]);
 
   return (
     <FormProvider {...methods}>
@@ -127,7 +137,7 @@ export const Register = () => {
               width="8.125rem"
               disabled={registerProductMutation.isPending}
             >
-              서비스 등록
+              {registerProductMutation.isPending ? '등록 중...' : '서비스 등록'}
             </BoxButton>
           </StyledRightContainer>
         </form>

--- a/src/drawer/pages/ServiceEdit/ServiceEdit.tsx
+++ b/src/drawer/pages/ServiceEdit/ServiceEdit.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { BoxButton } from '@yourssu/design-system-react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Loading } from '@/components/Loading/Loading';
 import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
@@ -12,7 +13,8 @@ import { ThumbnailInput } from '@/drawer/components/ThumbnailInput/ThumbnailInpu
 import { WarningBox } from '@/drawer/components/WarningBox/WarningBox';
 import { LINK, REGISTER_URL } from '@/drawer/constants/link.constant';
 import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
-import { usePostProduct } from '@/drawer/hooks/usePostProduct';
+import { registerFormDefaultValue } from '@/drawer/constants/registerFormDefaultValue.constant';
+import { usePutUpdateProduct } from '@/drawer/hooks/usePutUpdateProduct';
 import { RegisterFormValues } from '@/drawer/types/form.type';
 
 import {
@@ -25,24 +27,36 @@ import {
 import { useLoadServiceDetailEffect } from './useLoadServiceDetailEffect';
 
 export const ServiceEdit = () => {
-  const methods = useForm<RegisterFormValues>();
+  const { serviceId } = useParams();
+  const navigate = useNavigate();
+  const methods = useForm<RegisterFormValues>({ defaultValues: registerFormDefaultValue });
 
   const [linkExist, setLinkExist] = useState(true);
   const [isChecked, setIsChecked] = useState(false);
+  const registerProductMutation = usePutUpdateProduct(Number(serviceId));
 
   const validateLink = (name: string, value: string) => {
     return !value.startsWith(REGISTER_URL[name as keyof typeof REGISTER_URL]);
   };
 
-  const registerProductMutation = usePostProduct();
-
   const handleSubmit: SubmitHandler<RegisterFormValues> = (data) => {
+    console.log(data);
     if (isChecked) {
       registerProductMutation.mutate(data);
     }
   };
 
-  useLoadServiceDetailEffect(methods);
+  useEffect(() => {
+    if (registerProductMutation.isSuccess) {
+      alert('서비스가 수정되었습니다.');
+      navigate(`/drawer/services/${serviceId}`);
+    }
+  }, [registerProductMutation.isSuccess, serviceId, navigate]);
+
+  useLoadServiceDetailEffect({
+    serviceId: Number(serviceId),
+    setValue: methods.setValue,
+  });
 
   useEffect(() => {
     if (methods.formState.errors) {
@@ -125,13 +139,14 @@ export const ServiceEdit = () => {
 
           <StyledRightContainer>
             <BoxButton
+              type="submit"
               size={'medium'}
               variant={'filled'}
               rounding={4}
               width="8.125rem"
               disabled={registerProductMutation.isPending}
             >
-              서비스 등록
+              {registerProductMutation.isPending ? '수정 중...' : '서비스 수정'}
             </BoxButton>
           </StyledRightContainer>
         </form>

--- a/src/drawer/pages/ServiceEdit/ServiceEdit.tsx
+++ b/src/drawer/pages/ServiceEdit/ServiceEdit.tsx
@@ -40,18 +40,15 @@ export const ServiceEdit = () => {
   };
 
   const handleSubmit: SubmitHandler<RegisterFormValues> = (data) => {
-    console.log(data);
     if (isChecked) {
-      registerProductMutation.mutate(data);
+      registerProductMutation.mutate(data, {
+        onSuccess: () => {
+          alert('서비스가 수정되었습니다.');
+          navigate(`/drawer/services/${serviceId}`);
+        },
+      });
     }
   };
-
-  useEffect(() => {
-    if (registerProductMutation.isSuccess) {
-      alert('서비스가 수정되었습니다.');
-      navigate(`/drawer/services/${serviceId}`);
-    }
-  }, [registerProductMutation.isSuccess, serviceId, navigate]);
 
   useLoadServiceDetailEffect({
     serviceId: Number(serviceId),

--- a/src/drawer/pages/ServiceEdit/ServiceEdit.tsx
+++ b/src/drawer/pages/ServiceEdit/ServiceEdit.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+
+import { BoxButton } from '@yourssu/design-system-react';
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+
+import { Loading } from '@/components/Loading/Loading';
+import { CategoryWithoutAll } from '@/drawer/components/CategoryWithoutAll/CategoryWithoutAll';
+import { Input } from '@/drawer/components/Input/Input';
+import { OverviewImage } from '@/drawer/components/OverviewImage/OverviewImage';
+import { TextArea } from '@/drawer/components/TextArea/TextArea';
+import { ThumbnailInput } from '@/drawer/components/ThumbnailInput/ThumbnailInput';
+import { WarningBox } from '@/drawer/components/WarningBox/WarningBox';
+import { LINK, REGISTER_URL } from '@/drawer/constants/link.constant';
+import { MOBILE_VIEW_WIDTH } from '@/drawer/constants/mobileview.constant';
+import { usePostProduct } from '@/drawer/hooks/usePostProduct';
+import { RegisterFormValues } from '@/drawer/types/form.type';
+
+import {
+  StyledImportText,
+  StyledInputContainer,
+  StyledContainer as StyledRegisterContainer,
+  StyledRightContainer,
+} from '../Register/Register.style';
+
+import { useLoadServiceDetailEffect } from './useLoadServiceDetailEffect';
+
+export const ServiceEdit = () => {
+  const methods = useForm<RegisterFormValues>();
+
+  const [linkExist, setLinkExist] = useState(true);
+  const [isChecked, setIsChecked] = useState(false);
+
+  const validateLink = (name: string, value: string) => {
+    return !value.startsWith(REGISTER_URL[name as keyof typeof REGISTER_URL]);
+  };
+
+  const registerProductMutation = usePostProduct();
+
+  const handleSubmit: SubmitHandler<RegisterFormValues> = (data) => {
+    if (isChecked) {
+      registerProductMutation.mutate(data);
+    }
+  };
+
+  useLoadServiceDetailEffect(methods);
+
+  useEffect(() => {
+    if (methods.formState.errors) {
+      const { appStoreUrl, githubUrl, googlePlayUrl, webpageUrl } = methods.formState.errors;
+
+      if (appStoreUrl && githubUrl && googlePlayUrl && webpageUrl) {
+        setLinkExist(false);
+      }
+    }
+  }, [methods.formState]);
+
+  return (
+    <FormProvider {...methods}>
+      <StyledRegisterContainer>
+        {registerProductMutation.isPending && <Loading />}
+        <form onSubmit={methods.handleSubmit(handleSubmit)} id={'registerForm'}>
+          <StyledInputContainer>
+            <StyledRightContainer>
+              <StyledImportText $isWarned={false}>별표 표시 * 는 필수 입력란</StyledImportText>
+            </StyledRightContainer>
+
+            <Input
+              maxLength={20}
+              title={'서비스 이름'}
+              description={'(최대 20자)'}
+              required={true}
+              name={'title'}
+            />
+
+            <Input
+              maxLength={20}
+              title={'간단한 설명'}
+              description={'(최대 20자)'}
+              required={true}
+              name={'subtitle'}
+            />
+          </StyledInputContainer>
+
+          <TextArea
+            maxLength={5000}
+            title={'내용'}
+            description={'(최대 5000자)'}
+            required={true}
+            name={'content'}
+          />
+
+          <CategoryWithoutAll />
+
+          <StyledInputContainer>
+            <StyledRightContainer>
+              <StyledImportText $isWarned={!linkExist}>
+                {window.innerWidth < MOBILE_VIEW_WIDTH
+                  ? '웹 페이지, Google play, App store, Github\n링크 중 하나는 필수 기재 *'
+                  : '웹 페이지, Google play, App store, Github 링크 중 하나는 필수 기재 *'}
+              </StyledImportText>
+            </StyledRightContainer>
+
+            {LINK.map((link) => (
+              <Input
+                key={link.name}
+                maxLength={100}
+                title={link.title}
+                description={'(최대 100자)'}
+                validate={(value) => validateLink(link.name, value)}
+                name={link.name}
+              />
+            ))}
+          </StyledInputContainer>
+
+          <ThumbnailInput name={'thumbnailImage'} />
+
+          <OverviewImage />
+
+          <WarningBox
+            isSelected={isChecked}
+            handleSelected={() => {
+              setIsChecked((prev) => !prev);
+            }}
+          />
+
+          <StyledRightContainer>
+            <BoxButton
+              size={'medium'}
+              variant={'filled'}
+              rounding={4}
+              width="8.125rem"
+              disabled={registerProductMutation.isPending}
+            >
+              서비스 등록
+            </BoxButton>
+          </StyledRightContainer>
+        </form>
+      </StyledRegisterContainer>
+    </FormProvider>
+  );
+};

--- a/src/drawer/pages/ServiceEdit/useGetFilesFromURLs.ts
+++ b/src/drawer/pages/ServiceEdit/useGetFilesFromURLs.ts
@@ -1,0 +1,27 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+const parseUrlsToFiles = async (urls: string | string[] | undefined) => {
+  if (!urls) return [];
+  if (!Array.isArray(urls)) urls = [urls];
+
+  const files = await Promise.all(
+    urls.map(async (url) => {
+      const s3name = url.split('/').pop();
+      const response = await fetch(url, {
+        mode: 'cors',
+        credentials: 'include',
+      });
+      const blob = await response.blob();
+      return new File([blob], `${s3name}.png`, { type: 'image/png' });
+    })
+  );
+
+  return files;
+};
+
+export const useGetFilesFromURLs = (urls: string | string[] | undefined) => {
+  return useSuspenseQuery({
+    queryKey: ['urlToFile', ...(urls ?? [])],
+    queryFn: () => parseUrlsToFiles(urls),
+  });
+};

--- a/src/drawer/pages/ServiceEdit/useLoadServiceDetailEffect.ts
+++ b/src/drawer/pages/ServiceEdit/useLoadServiceDetailEffect.ts
@@ -1,22 +1,60 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { UseFormReturn } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
+import { EMAIL_DOMAIN } from '@/constants/email.constant';
 import { useGetProductDetail } from '@/drawer/hooks/useGetProductDetail';
 import { CategoryState } from '@/drawer/recoil/CategoryState';
 import { RegisterFormValues } from '@/drawer/types/form.type';
+import { useGetUserData } from '@/home/hooks/useGetUserData';
 
-export const useLoadServiceDetailEffect = ({ setValue }: UseFormReturn<RegisterFormValues>) => {
-  const { serviceId } = useParams();
-  const { data: product } = useGetProductDetail(Number(serviceId));
+import { useGetFilesFromURLs } from './useGetFilesFromURLs';
+
+type UseLoadServiceDetailEffectProps = {
+  serviceId: number;
+  setValue: UseFormReturn<RegisterFormValues>['setValue'];
+};
+
+export const useLoadServiceDetailEffect = ({
+  serviceId,
+  setValue,
+}: UseLoadServiceDetailEffectProps) => {
+  // 본인이 등록한 서비스인지 확인하기 전까지는
+  // 폼에 값을 채우지 않기 위해 isValidated를 사용합니다.
+  const [isValidated, setIsValidated] = useState(false);
+
   const setSelectedCategory = useSetRecoilState(CategoryState);
+  const navigate = useNavigate();
+  const { data: userData, isLoading: isUserDataLoading } = useGetUserData();
+  const { data: product, isLoading: isProductLoading } = useGetProductDetail(serviceId);
 
-  // const { data: thumbnailFiles } = useGetURLsToFiles(product?.thumbnail);
-  // const { data: introductionFiles } = useGetURLsToFiles(product?.introductionImage);
+  const { data: thumbnailFiles, isLoading: isThumbnailLoading } = useGetFilesFromURLs(
+    product?.thumbnail
+  );
+  const { data: introductionFiles, isLoading: isIntroductionsLoading } = useGetFilesFromURLs(
+    product?.introductionImage
+  );
 
   useEffect(() => {
+    if (isUserDataLoading || isProductLoading) return;
+
+    const productProviderEmail = `${product.providerId}${EMAIL_DOMAIN}`;
+    const currentUserEmail = userData?.email;
+
+    if (productProviderEmail !== currentUserEmail) {
+      navigate('/');
+      return;
+    }
+
+    setIsValidated(true);
+  }, [product, userData, isUserDataLoading, isProductLoading, navigate]);
+
+  useEffect(() => {
+    if (!isValidated) return;
+    if (isThumbnailLoading || isIntroductionsLoading) return;
+
     const {
       productTitle,
       productSubTitle,
@@ -28,14 +66,25 @@ export const useLoadServiceDetailEffect = ({ setValue }: UseFormReturn<RegisterF
       githubUrl,
     } = product;
 
-    setValue('title', productTitle);
-    setValue('subtitle', productSubTitle);
-    setValue('content', productContent);
-    setValue('category', category);
+    setValue('title', productTitle, { shouldValidate: true });
+    setValue('subtitle', productSubTitle, { shouldValidate: true });
+    setValue('content', productContent, { shouldValidate: true });
+    setValue('category', category, { shouldValidate: true });
     setSelectedCategory(category);
-    setValue('webpageUrl', webpageUrl ?? '');
-    setValue('googlePlayUrl', googlePlayUrl ?? '');
-    setValue('appStoreUrl', appStoreUrl ?? '');
-    setValue('githubUrl', githubUrl ?? '');
-  }, [product, setValue, setSelectedCategory]);
+    setValue('webpageUrl', webpageUrl ?? '', { shouldValidate: true });
+    setValue('googlePlayUrl', googlePlayUrl ?? '', { shouldValidate: true });
+    setValue('appStoreUrl', appStoreUrl ?? '', { shouldValidate: true });
+    setValue('githubUrl', githubUrl ?? '', { shouldValidate: true });
+    setValue('thumbnailImage', thumbnailFiles), { shouldValidate: true };
+    setValue('introductionImages', introductionFiles, { shouldValidate: true });
+  }, [
+    isValidated,
+    product,
+    setValue,
+    setSelectedCategory,
+    thumbnailFiles,
+    introductionFiles,
+    isThumbnailLoading,
+    isIntroductionsLoading,
+  ]);
 };

--- a/src/drawer/pages/ServiceEdit/useLoadServiceDetailEffect.ts
+++ b/src/drawer/pages/ServiceEdit/useLoadServiceDetailEffect.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+import { UseFormReturn } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+
+import { useGetProductDetail } from '@/drawer/hooks/useGetProductDetail';
+import { CategoryState } from '@/drawer/recoil/CategoryState';
+import { RegisterFormValues } from '@/drawer/types/form.type';
+
+export const useLoadServiceDetailEffect = ({ setValue }: UseFormReturn<RegisterFormValues>) => {
+  const { serviceId } = useParams();
+  const { data: product } = useGetProductDetail(Number(serviceId));
+  const setSelectedCategory = useSetRecoilState(CategoryState);
+
+  // const { data: thumbnailFiles } = useGetURLsToFiles(product?.thumbnail);
+  // const { data: introductionFiles } = useGetURLsToFiles(product?.introductionImage);
+
+  useEffect(() => {
+    const {
+      productTitle,
+      productSubTitle,
+      productContent,
+      category,
+      webpageUrl,
+      googlePlayUrl,
+      appStoreUrl,
+      githubUrl,
+    } = product;
+
+    setValue('title', productTitle);
+    setValue('subtitle', productSubTitle);
+    setValue('content', productContent);
+    setValue('category', category);
+    setSelectedCategory(category);
+    setValue('webpageUrl', webpageUrl ?? '');
+    setValue('googlePlayUrl', googlePlayUrl ?? '');
+    setValue('appStoreUrl', appStoreUrl ?? '');
+    setValue('githubUrl', githubUrl ?? '');
+  }, [product, setValue, setSelectedCategory]);
+};

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -41,6 +41,11 @@ const ServiceDetail = lazy(() =>
     default: ServiceDetail,
   }))
 );
+const ServiceEdit = lazy(() =>
+  import('./drawer/pages/ServiceEdit/ServiceEdit').then(({ ServiceEdit }) => ({
+    default: ServiceEdit,
+  }))
+);
 const StarRanking = lazy(() =>
   import('./drawer/pages/StarRanking/StarRanking').then(({ StarRanking }) => ({
     default: StarRanking,
@@ -128,6 +133,7 @@ export const Router = () => {
           <Route path="/withdraw" element={<Withdraw />}></Route>
           <Route path="/drawer" element={<DrawerLayout />}>
             <Route index element={<Navigate to="rankings" replace />}></Route>
+            <Route path="services/:serviceId/edit" element={<ServiceEdit />} />
             <Route path="services/:serviceId" element={<ServiceDetail />} />
             <Route path="rankings" element={<Ranking />} />
             <Route path="register" element={<Register />} />


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #235 

리뷰 환영

생각보다 난이도가 있었던 작업이었습니다..  
그리고 CORS 문제 때문에 좀 예상보다 작업 기간이 길어졌네요 죄송함다

아래 작업들을 수행했습니다.   
- 서비스 수정 라우트 제작 (`/drawer/services/<:productNo>/edit`)

- 서랍장 서비스 수정 페이지 퍼블리싱 (`<ServiceEdit />`)
- 수정 페이지 진입 시 폼 채워지는 기능 구현
- 올바르지 않은 사용자가 수정 라우트 접근 시 홈으로 리다이렉트
- `CardSettingDropDownMenu` 에 `background-color` 추가
- 서랍장 서비스 등록 및 수정 페이지에서 submit시 중복 클릭 방지 및 성공 시 navigate 기능
  - 서비스 등록 성공 시: '내가 등록한 서비스' 페이지로 이동 (`/drawer/myDrawers?tab=MYDRAWER`)
  - 서비스 수정 성공 시: 해당 서비스 detatil 페이지로 이동

![화면 기록 2024-06-25 05 39 23](https://github.com/yourssu/Soomsil-Web/assets/101973955/cdead770-ee50-4674-864d-8ec078a34e92)


### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

### 1. 기존 서비스 등록 페이지의 하위 컴포넌트들 리팩토링

수정 페이지 컴포넌트인 `<ServiceEdit />` 은 기본적인 로직이  
서비스 등록 페이지 컴포넌트인 `<Register />` 와 로직이 완전히 동일합니다.

서비스 등록 페이지의 폼을 그대로 가져와서   
폼에 값만 채우자고  계획했었기 때문인데요.

이 과정에서 의도치않게 폼에 존재하는 input 관련 컴포넌트들에 대하여 
아래의 리팩토링이 적용되었습니다.

- RHF를 사용하지만 input의 값을 상태로 관리하던 모든 로직 제거
- 폼에 기본 값 추가 (`registerFormDefaultValue.constant.ts`)
- 자잘한 코드 호출 방식 수정

리팩토링 이전과 일치하게 동작하도록 하였습니다.  
리뷰시 참고하면 좋을듯해요

### 2. 서비스 등록 성공 시 로직 추가

기존에는 서비스 등록 성공 시 웹에서 아무런 응답을 주지 않았습니다. (alert, navigate 등)

서비스 수정 페이지 구현하는 김에 이 부분도 보완하여  
이제는 성공 시 alert와 함께 본인이 등록한 서비스 페이지로 이동합니다.

### 버그 픽스

![스크린샷 2024-06-25 05 56 34](https://github.com/yourssu/Soomsil-Web/assets/101973955/23bf2156-aed5-4f15-a950-a70a8e4cd6f2)

`CardSettingDropDownMenu`에 배경 색상이 적용되어있지 않던 문제를 발견했습니다.

이 pr에서 같이 해결했습니다.

## 2️⃣ 알아두시면 좋아요!

![스크린샷 2024-06-25 06 08 06](https://github.com/yourssu/Soomsil-Web/assets/101973955/284cf1e2-2fdd-423b-8c61-3a1504126f5d)

## 3️⃣ 추후 작업

- 아마 여유가 된다면 Register 페이지와 ServiceEdit에 공통적으로 들어간 로직을 묶는 작업?
- (이것도 여유가 된다면) 아무것도 변경하지 않았다면 폼 수정을 실패하게 만드는 로직 ?

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?

## 질문

@2wndrhs 

`/src/drawer/components/Category/RegisterCategory/RegisterCategory.tsx` 에서,
`CategoryState` 전역상태를 사용해서 구현하신 특별한 이유가 있나요??

어차피 선택된 카테고리는 `useFormContext` 를 따라 이동할텐데,
혹시 의도하신 effect가 있는지 궁금해서 여쭤봅니다!!

임시로 useEffect로 초기화시키게 만들어두긴했는데,  
저거 냅두면 다른곳에서 카테고리 선택하고 수정 및 등록 페이지로 들어왔을 때
카테고리가 미리 그거로 선택되는 경우가 생겨버려서...

미처 발견못하신거면 이 pr에서 개선하려고합니다!!

