### PR TITLE
feat: 회원가입 페이지에 학교 메일 찾기 링크 걸기

### DIFF
--- a/src/constants/email.constant.ts
+++ b/src/constants/email.constant.ts
@@ -1,1 +1,3 @@
 export const EMAIL_DOMAIN = '@soongsil.ac.kr';
+
+export const MAIL_SEARCH_URL = 'https://gw.ssu.ac.kr/o365Userlogin.aspx';

--- a/src/home/components/ResetPasswordContents/EmailInput/EmailInput.tsx
+++ b/src/home/components/ResetPasswordContents/EmailInput/EmailInput.tsx
@@ -3,7 +3,7 @@ import { BoxButton, SuffixTextField } from '@yourssu/design-system-react';
 import { EMAIL_DOMAIN } from '@/constants/email.constant';
 
 import { StyledEmailContainer, StyledSubTitleText, StyledTitleText } from './EmailInput.style';
-import { useEmailInput } from './useEmailInputForm';
+import { useEmailInputForm } from './useEmailInputForm';
 
 interface EmailInputProps {
   email: string;
@@ -11,7 +11,7 @@ interface EmailInputProps {
 }
 
 export const EmailInput = ({ email, onConfirm }: EmailInputProps) => {
-  const { register, handleSubmit, errors, isSubmitting, handleOnSubmit } = useEmailInput({
+  const { register, handleSubmit, errors, isSubmitting, handleOnSubmit } = useEmailInputForm({
     email,
     onConfirm,
   });

--- a/src/home/components/ResetPasswordContents/EmailInput/useEmailInputForm.ts
+++ b/src/home/components/ResetPasswordContents/EmailInput/useEmailInputForm.ts
@@ -12,7 +12,7 @@ interface FormData {
   email: string;
 }
 
-export const useEmailInput = ({ email, onConfirm }: EmailInputProps) => {
+export const useEmailInputForm = ({ email, onConfirm }: EmailInputProps) => {
   const {
     register,
     handleSubmit,

--- a/src/home/components/SignupContents/EmailForm/EmailForm.style.ts
+++ b/src/home/components/SignupContents/EmailForm/EmailForm.style.ts
@@ -30,3 +30,11 @@ export const StyledEmailSuffix = styled.div`
 export const StyledEmailFieldWrapper = styled.div`
   ${({ theme }) => theme.typo.body1};
 `;
+
+export const StyledLink = styled.a`
+  ${({ theme }) => theme.typo.button3};
+  color: inherit;
+  &:visited {
+    color: inherit;
+  }
+`;

--- a/src/home/components/SignupContents/EmailForm/EmailForm.tsx
+++ b/src/home/components/SignupContents/EmailForm/EmailForm.tsx
@@ -1,6 +1,6 @@
 import { BoxButton, PlainButton, SuffixTextField } from '@yourssu/design-system-react';
 
-import { EMAIL_DOMAIN } from '@/constants/email.constant';
+import { EMAIL_DOMAIN, MAIL_SEARCH_URL } from '@/constants/email.constant';
 import { EmailFormProps } from '@/home/components/SignupContents/EmailForm/EmailForm.type.ts';
 import { useEmailForm } from '@/home/components/SignupContents/EmailForm/useEmailForm.ts';
 import { usePreventDuplicateClick } from '@/hooks/usePreventDuplicateClick.ts';
@@ -14,6 +14,7 @@ import {
 import {
   StyledButtonsContainer,
   StyledEmailFieldWrapper,
+  StyledLink,
   StyledPlainButtonWrapper,
   StyledTextFieldLabel,
 } from './EmailForm.style';
@@ -42,7 +43,11 @@ export const EmailForm = ({ onConfirm }: EmailFormProps) => {
       <StyledButtonsContainer>
         <StyledPlainButtonWrapper>
           <PlainButton type="button" size="medium" isPointed={false} isWarned={false}>
-            <StyledSignupButtonText>학교 메일 찾기</StyledSignupButtonText>
+            <StyledSignupButtonText>
+              <StyledLink href={MAIL_SEARCH_URL} target="_blank" rel="noopener noreferrer">
+                학교 메일 찾기
+              </StyledLink>
+            </StyledSignupButtonText>
           </PlainButton>
         </StyledPlainButtonWrapper>
         <BoxButton

--- a/src/home/pages/Login/Login.tsx
+++ b/src/home/pages/Login/Login.tsx
@@ -7,7 +7,7 @@ import {
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
-import { EMAIL_DOMAIN } from '@/constants/email.constant';
+import { EMAIL_DOMAIN, MAIL_SEARCH_URL } from '@/constants/email.constant';
 import { StyledSignupContentTitle } from '@/home/components/SignupContents/SignupContents.style';
 import { SignupFrame } from '@/home/components/SignupFrame/SignupFrame';
 import { usePostLogin } from '@/home/hooks/usePostLogin';
@@ -29,8 +29,6 @@ interface LoginFormStates {
 
 export const Login = () => {
   const { register, handleSubmit } = useForm<LoginFormStates>();
-  const MAIL_SEARCH_URL = 'https://gw.ssu.ac.kr/o365Userlogin.aspx';
-
   const navigate = useNavigate();
   const parseFullEmail = useParseFullEmail();
   const loginMutation = usePostLogin();

--- a/src/home/pages/Signup/Signup.tsx
+++ b/src/home/pages/Signup/Signup.tsx
@@ -7,6 +7,7 @@ import { SignupEnd } from '@/home/components/SignupContents/SignupEnd/SignupEnd'
 import { SignupForm } from '@/home/components/SignupContents/SignupForm/SignupForm';
 import { SignupFrame } from '@/home/components/SignupFrame/SignupFrame';
 import { useFunnel } from '@/hooks/useFunnel.tsx';
+import { useRedirectLoggedInEffect } from '@/hooks/useRedirectLoggedInEffect';
 
 type SignupFunnelStepsType =
   | '약관동의'
@@ -18,6 +19,8 @@ type SignupFunnelStepsType =
 export const Signup = () => {
   const [Funnel, setStep] = useFunnel<SignupFunnelStepsType>('약관동의');
   const [email, setEmail] = useState('');
+
+  useRedirectLoggedInEffect();
 
   return (
     <SignupFrame>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #245 

- `email.constant.ts`에 학교 메일 찾는 링크를 추가해서 전역으로 갖다 쓰게 했습니다.

### 버그 픽스
- 회원가입 페이지에 `useRedirectLoggedInEffect`를 사용해 로그인 상태에서 접근을 막았습니다.
- 이전 pr에서 수정하지 못한 [훅 이름 변경](https://github.com/yourssu/Soomsil-Web/pull/233#discussion_r1652705310)을 슬쩍 같이 했습니다.

## 2️⃣ 알아두시면 좋아요!
- 혹시나 궁금해하실까봐 [`rel="noopener noreferrer"`는 어떤 역할을 하는 건가요?](https://github.com/yourssu/Soomsil-Web/pull/233#discussion_r1652725446)

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
