### PR TITLE
refactor: 서랍장 상세 페이지 배경 이미지를 삭제하고 배경 색상 추가

### DIFF
--- a/src/drawer/pages/ServiceDetail/ServiceDetail.style.ts
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.style.ts
@@ -9,18 +9,14 @@ export const StyledServiceDetailContainer = styled.div`
   padding-bottom: 10rem;
 `;
 
-interface StyledBackgroundImageContainerProps {
-  $backgroundImage: string;
-}
-
-export const StyledBackgroundImageContainer = styled.div<StyledBackgroundImageContainerProps>`
+export const StyledBackgroundContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
   height: 55vh;
   justify-content: flex-end;
-  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
-    url(${(props) => props.$backgroundImage});
+  background-color: #1d2023;
+
   padding-left: 17vw;
   padding-bottom: 5vh;
 

--- a/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
+++ b/src/drawer/pages/ServiceDetail/ServiceDetail.tsx
@@ -7,7 +7,7 @@ import { CategoryObj } from '@/drawer/constants/category.constant';
 import { useGetProductDetail } from '@/drawer/hooks/useGetProductDetail';
 
 import {
-  StyledBackgroundImageContainer,
+  StyledBackgroundContainer,
   StyledCategoryContainer,
   StyledCategoryHintText,
   StyledCategoryText,
@@ -25,7 +25,7 @@ export const ServiceDetail = () => {
 
   return (
     <StyledServiceDetailContainer>
-      <StyledBackgroundImageContainer $backgroundImage={product.thumbnail}>
+      <StyledBackgroundContainer>
         <StyledServiceTitleText>{product.productTitle}</StyledServiceTitleText>
         <StyledServiceDeveloperText>{product.providerName}</StyledServiceDeveloperText>
         <StyledServiceInfoContainer>
@@ -36,7 +36,7 @@ export const ServiceDetail = () => {
           </StyledCategoryContainer>
         </StyledServiceInfoContainer>
         <ServiceAction product={product} />
-      </StyledBackgroundImageContainer>
+      </StyledBackgroundContainer>
       <StyledLowerSection>
         <Description product={product} />
         <MoreProductSection providerId={product.providerId} />


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #251

### 기존 코드에 영향을 미치지 않는 변경사항

- 상세 페이지 커버 이미지(?)에 대한 수정 요청이 들어와서 고쳤어요

![image](https://github.com/yourssu/Soomsil-Web/assets/87255462/c55ff904-87d5-43f2-bc8b-2d7f043275c3)

사진 대신 어두운 컬러 단색 배경으로 수정했습니다!
사진이 들어갈 때는 프로덕트 정보 부분이 잘 안보이는 일이 있어서요 (이슈 참고)

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
