### PR TITLE
fix: 서랍장 서비스 등록 페이지의 `textarea` 요소의 배경색을 흰색으로 수정

### DIFF
--- a/src/drawer/components/Header/Header.style.ts
+++ b/src/drawer/components/Header/Header.style.ts
@@ -64,6 +64,7 @@ export const StyledHeaderSearchContainer = styled.div`
 
 export const StyledHeaderSearchInput = styled.input`
   width: 100%;
+  color: ${({ theme }) => theme.color.textPrimary};
   height: 1.25rem;
   border: none;
   outline: none;

--- a/src/drawer/components/TextArea/TextArea.style.ts
+++ b/src/drawer/components/TextArea/TextArea.style.ts
@@ -66,6 +66,8 @@ export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
   }
 
   ${({ theme }) => theme.typo.button4};
+
+  background-color: white;
   color: ${({ $isWarned, theme }) =>
     $isWarned ? theme.color.buttonWarned : theme.color.textSecondary};
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #254 
![image](https://github.com/yourssu/Soomsil-Web/assets/76615094/a64a4c37-c14a-4b3e-8758-d78c2fecb59e)


### 버그 픽스
- `src/drawer/components/TextArea/TextArea.style.ts`
  - 다크모드에서 서랍장 서비스 등록 페이지의 내용 입력 폼(`textarea`)의 배경색이 검정색으로 표시되는 문제가 있어 배경색을 흰색으로 명시하였습니다.

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
