### PR TITLE
fix: 검색 결과 1개에서 썸네일이 없는 경우 글만 나타나게 수정

### DIFF
--- a/src/search/components/ResultList/ResultListItem.style.ts
+++ b/src/search/components/ResultList/ResultListItem.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { RESULT_LIST_ITEM_THUMNAIL_LENGTH } from '@/search/constant';
+import { RESULT_LIST_ITEM_THUMBNAIL_LENGTH } from '@/search/constant';
 
 export const StyledResultListItem = styled.section`
   display: flex;
@@ -18,7 +18,7 @@ interface StyledContentProps {
 }
 
 export const StyledContentWrap = styled.div<StyledContentProps>`
-  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? '37.563rem' : '100%')};
+  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '37.563rem' : '100%')};
 `;
 
 export const StyledInformationWrap = styled.div`
@@ -66,7 +66,7 @@ export const StyledTitle = styled.a<StyledTitleProps>`
   word-wrap: break-word;
   display: -webkit-box;
   overflow: hidden;
-  -webkit-line-clamp: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? 1 : 2)};
+  -webkit-line-clamp: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 1 : 2)};
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
 
@@ -84,11 +84,11 @@ export const StyledContent = styled.div<StyledContentProps>`
   ${(props) => props.theme.typo.body1}
   color: ${(props) => props.theme.color.textTertiary};
   width: 100%;
-  height: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? 4.688 : 3.25)}rem;
+  height: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 4.688 : 3.25)}rem;
   word-wrap: break-word;
   display: -webkit-box;
   overflow: hidden;
-  -webkit-line-clamp: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? 3 : 2)};
+  -webkit-line-clamp: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 3 : 2)};
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
 `;
@@ -98,7 +98,7 @@ interface StyledThumbnailProps {
 }
 
 export const StyledThumbnail = styled.div<StyledThumbnailProps>`
-  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? '8.125rem' : '100%')};
+  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '8.125rem' : '100%')};
   height: 8.125rem;
   align-self: flex-end;
   position: relative;
@@ -109,7 +109,7 @@ export const StyledThumbnail = styled.div<StyledThumbnailProps>`
 `;
 
 export const StyledThumbnailImage = styled.img<StyledThumbnailProps>`
-  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? '100%' : '20%')};
+  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '100%' : '20%')};
   height: 100%;
   align-self: flex-end;
   background: linear-gradient(
@@ -118,7 +118,7 @@ export const StyledThumbnailImage = styled.img<StyledThumbnailProps>`
     rgba(212.91, 212.91, 212.91, 0.2) 100%
   );
   aspect-ratio: ${(props) =>
-    props.$length < RESULT_LIST_ITEM_THUMNAIL_LENGTH ? 'auto 130/130' : 'auto 148.8/130'};
+    props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 'auto 130/130' : 'auto 148.8/130'};
   overflow: clip;
   overflow-clip-margin: content-box;
   object-fit: cover;

--- a/src/search/components/ResultList/ResultListItem.style.ts
+++ b/src/search/components/ResultList/ResultListItem.style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 export const StyledResultListItem = styled.section`
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   box-sizing: border-box;
   width: 50rem;
@@ -13,6 +14,7 @@ export const StyledResultListItem = styled.section`
 
 export const StyledContentWrap = styled.div<{ $isHorizontalLayout: boolean }>`
   width: ${({ $isHorizontalLayout }) => ($isHorizontalLayout ? '37.563rem' : '100%')};
+  flex-shrink: 0;
 `;
 
 export const StyledInformationWrap = styled.div`
@@ -88,6 +90,8 @@ export const StyledThumbnail = styled.div<{ $isVerticalLayout: boolean }>`
   overflow: hidden;
   display: flex;
   gap: 0.125rem;
+  flex-shrink: 0;
+  margin-top: ${({ $isVerticalLayout }) => ($isVerticalLayout ? '12px' : '0')};
 `;
 
 export const StyledThumbnailImage = styled.img<{ $isVerticalLayout: boolean }>`

--- a/src/search/components/ResultList/ResultListItem.style.ts
+++ b/src/search/components/ResultList/ResultListItem.style.ts
@@ -18,7 +18,8 @@ interface StyledContentProps {
 }
 
 export const StyledContentWrap = styled.div<StyledContentProps>`
-  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '37.563rem' : '100%')};
+  width: ${(props) =>
+    props.$length > 0 && props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '37.563rem' : '100%'};
 `;
 
 export const StyledInformationWrap = styled.div`

--- a/src/search/components/ResultList/ResultListItem.style.ts
+++ b/src/search/components/ResultList/ResultListItem.style.ts
@@ -1,7 +1,5 @@
 import styled from 'styled-components';
 
-import { RESULT_LIST_ITEM_THUMBNAIL_LENGTH } from '@/search/constant';
-
 export const StyledResultListItem = styled.section`
   display: flex;
   justify-content: space-between;
@@ -13,13 +11,8 @@ export const StyledResultListItem = styled.section`
   cursor: pointer;
 `;
 
-interface StyledContentProps {
-  $length: number;
-}
-
-export const StyledContentWrap = styled.div<StyledContentProps>`
-  width: ${(props) =>
-    props.$length > 0 && props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '37.563rem' : '100%'};
+export const StyledContentWrap = styled.div<{ $isHorizontalLayout: boolean }>`
+  width: ${({ $isHorizontalLayout }) => ($isHorizontalLayout ? '37.563rem' : '100%')};
 `;
 
 export const StyledInformationWrap = styled.div`
@@ -55,11 +48,7 @@ export const StyledDate = styled.span`
   color: ${(props) => props.theme.color.textTertiary};
 `;
 
-interface StyledTitleProps {
-  $length: number;
-}
-
-export const StyledTitle = styled.a<StyledTitleProps>`
+export const StyledTitle = styled.a<{ $isVerticalLayout: boolean }>`
   ${(props) => props.theme.typo.title3}
   width: 100%;
   height: fit-content;
@@ -67,7 +56,7 @@ export const StyledTitle = styled.a<StyledTitleProps>`
   word-wrap: break-word;
   display: -webkit-box;
   overflow: hidden;
-  -webkit-line-clamp: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 1 : 2)};
+  -webkit-line-clamp: ${({ $isVerticalLayout }) => ($isVerticalLayout ? 2 : 1)};
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
 
@@ -77,29 +66,21 @@ export const StyledTitle = styled.a<StyledTitleProps>`
   }
 `;
 
-interface StyledContentProps {
-  $length: number;
-}
-
-export const StyledContent = styled.div<StyledContentProps>`
+export const StyledContent = styled.div<{ $isVerticalLayout: boolean }>`
   ${(props) => props.theme.typo.body1}
   color: ${(props) => props.theme.color.textTertiary};
   width: 100%;
-  height: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 4.688 : 3.25)}rem;
+  height: ${({ $isVerticalLayout }) => ($isVerticalLayout ? 3.25 : 4.688)}rem;
   word-wrap: break-word;
   display: -webkit-box;
   overflow: hidden;
-  -webkit-line-clamp: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 3 : 2)};
+  -webkit-line-clamp: ${({ $isVerticalLayout }) => ($isVerticalLayout ? 2 : 3)};
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
 `;
 
-interface StyledThumbnailProps {
-  $length: number;
-}
-
-export const StyledThumbnail = styled.div<StyledThumbnailProps>`
-  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '8.125rem' : '100%')};
+export const StyledThumbnail = styled.div<{ $isVerticalLayout: boolean }>`
+  width: ${({ $isVerticalLayout }) => ($isVerticalLayout ? '100%' : '8.125rem')};
   height: 8.125rem;
   align-self: flex-end;
   position: relative;
@@ -109,8 +90,8 @@ export const StyledThumbnail = styled.div<StyledThumbnailProps>`
   gap: 0.125rem;
 `;
 
-export const StyledThumbnailImage = styled.img<StyledThumbnailProps>`
-  width: ${(props) => (props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? '100%' : '20%')};
+export const StyledThumbnailImage = styled.img<{ $isVerticalLayout: boolean }>`
+  width: ${({ $isVerticalLayout }) => ($isVerticalLayout ? '20%' : '100%')};
   height: 100%;
   align-self: flex-end;
   background: linear-gradient(
@@ -118,8 +99,8 @@ export const StyledThumbnailImage = styled.img<StyledThumbnailProps>`
     rgba(212.91, 212.91, 212.91, 0.2) 0%,
     rgba(212.91, 212.91, 212.91, 0.2) 100%
   );
-  aspect-ratio: ${(props) =>
-    props.$length < RESULT_LIST_ITEM_THUMBNAIL_LENGTH ? 'auto 130/130' : 'auto 148.8/130'};
+  aspect-ratio: ${({ $isVerticalLayout }) =>
+    $isVerticalLayout ? 'auto 148.8/130' : 'auto 130/130'};
   overflow: clip;
   overflow-clip-margin: content-box;
   object-fit: cover;

--- a/src/search/components/ResultList/ResultListItem.tsx
+++ b/src/search/components/ResultList/ResultListItem.tsx
@@ -47,23 +47,6 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
           <StyledTitle $isVerticalLayout={isVerticalLayout}>{title}</StyledTitle>
           <Spacing direction="vertical" size={8} />
           <StyledContent $isVerticalLayout={isVerticalLayout}>{content}</StyledContent>
-          {isVerticalLayout && (
-            <>
-              <Spacing direction="vertical" size={12} />
-              <StyledThumbnail $isVerticalLayout={isVerticalLayout}>
-                {Array.from({ length: 5 }).map((_, index) => (
-                  <StyledThumbnailImage
-                    key={thumbnail[index]}
-                    $isVerticalLayout={isVerticalLayout}
-                    src={thumbnail[index] || '/'}
-                    alt="썸네일"
-                    onError={onErrorImg}
-                  ></StyledThumbnailImage>
-                ))}
-                <StyledThumbnailCountBox>{thumbnail.length}</StyledThumbnailCountBox>
-              </StyledThumbnail>
-            </>
-          )}
         </StyledContentWrap>
         {isHorizontalLayout && (
           <StyledThumbnail $isVerticalLayout={isVerticalLayout}>
@@ -73,6 +56,20 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
               alt="썸네일"
               onError={onErrorImg}
             ></StyledThumbnailImage>
+            <StyledThumbnailCountBox>{thumbnail.length}</StyledThumbnailCountBox>
+          </StyledThumbnail>
+        )}
+        {isVerticalLayout && (
+          <StyledThumbnail $isVerticalLayout={isVerticalLayout}>
+            {Array.from({ length: 5 }).map((_, index) => (
+              <StyledThumbnailImage
+                key={thumbnail[index]}
+                $isVerticalLayout={isVerticalLayout}
+                src={thumbnail[index] || '/'}
+                alt="썸네일"
+                onError={onErrorImg}
+              ></StyledThumbnailImage>
+            ))}
             <StyledThumbnailCountBox>{thumbnail.length}</StyledThumbnailCountBox>
           </StyledThumbnail>
         )}

--- a/src/search/components/ResultList/ResultListItem.tsx
+++ b/src/search/components/ResultList/ResultListItem.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 
 import { Spacing } from '@/components/Spacing/Spacing';
+import { RESULT_LIST_ITEM_THUMBNAIL_LENGTH } from '@/search/constant';
 import { ResultListItemResponse } from '@/search/types/ResultListItem.type';
 import { onErrorImg } from '@/search/utils/onErrorImg';
 
@@ -25,6 +26,9 @@ interface ResultListItemProps
 
 export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
   ({ title, content, date, thumbnail, favicon, source, onClick }, ref) => {
+    const isVerticalLayout = thumbnail.length >= RESULT_LIST_ITEM_THUMBNAIL_LENGTH;
+    const isHorizontalLayout = !isVerticalLayout && thumbnail.length > 0;
+
     return (
       <StyledResultListItem ref={ref} onClick={onClick}>
         <StyledContentWrap $length={thumbnail.length}>
@@ -43,7 +47,7 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
           <StyledTitle $length={thumbnail.length}>{title}</StyledTitle>
           <Spacing direction="vertical" size={8} />
           <StyledContent $length={thumbnail.length}>{content}</StyledContent>
-          {thumbnail.length >= 5 && (
+          {isVerticalLayout && (
             <>
               <Spacing direction="vertical" size={12} />
               <StyledThumbnail $length={thumbnail.length}>
@@ -61,7 +65,7 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
             </>
           )}
         </StyledContentWrap>
-        {thumbnail.length < 5 && (
+        {isHorizontalLayout && (
           <StyledThumbnail $length={thumbnail.length}>
             <StyledThumbnailImage
               $length={thumbnail.length}

--- a/src/search/components/ResultList/ResultListItem.tsx
+++ b/src/search/components/ResultList/ResultListItem.tsx
@@ -31,7 +31,7 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
 
     return (
       <StyledResultListItem ref={ref} onClick={onClick}>
-        <StyledContentWrap $length={thumbnail.length}>
+        <StyledContentWrap $isHorizontalLayout={isHorizontalLayout}>
           <StyledInformationWrap>
             <StyledLinkImageWrap>
               <StyledLinkImage src={favicon || '/'} alt="favicon" onError={onErrorImg} />
@@ -44,17 +44,17 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
             <StyledDate>{date}</StyledDate>
           </StyledInformationWrap>
           <Spacing direction="vertical" size={12} />
-          <StyledTitle $length={thumbnail.length}>{title}</StyledTitle>
+          <StyledTitle $isVerticalLayout={isVerticalLayout}>{title}</StyledTitle>
           <Spacing direction="vertical" size={8} />
-          <StyledContent $length={thumbnail.length}>{content}</StyledContent>
+          <StyledContent $isVerticalLayout={isVerticalLayout}>{content}</StyledContent>
           {isVerticalLayout && (
             <>
               <Spacing direction="vertical" size={12} />
-              <StyledThumbnail $length={thumbnail.length}>
+              <StyledThumbnail $isVerticalLayout={isVerticalLayout}>
                 {Array.from({ length: 5 }).map((_, index) => (
                   <StyledThumbnailImage
                     key={thumbnail[index]}
-                    $length={thumbnail.length}
+                    $isVerticalLayout={isVerticalLayout}
                     src={thumbnail[index] || '/'}
                     alt="썸네일"
                     onError={onErrorImg}
@@ -66,9 +66,9 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
           )}
         </StyledContentWrap>
         {isHorizontalLayout && (
-          <StyledThumbnail $length={thumbnail.length}>
+          <StyledThumbnail $isVerticalLayout={isVerticalLayout}>
             <StyledThumbnailImage
-              $length={thumbnail.length}
+              $isVerticalLayout={isVerticalLayout}
               src={thumbnail[0] || '/'}
               alt="썸네일"
               onError={onErrorImg}

--- a/src/search/constant/index.ts
+++ b/src/search/constant/index.ts
@@ -34,7 +34,7 @@ export const SEARCH_BOX_RADIAL_GRADIENT: Record<string, Record<SearchSize, strin
   },
 };
 
-export const RESULT_LIST_ITEM_THUMNAIL_LENGTH = 5;
+export const RESULT_LIST_ITEM_THUMBNAIL_LENGTH = 5;
 
 export const NAVIGATION_OPTIONS = {
   HOME: 'home',


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #282

### 기존 코드에 영향을 미치는 변경사항

- 검색 결과에서 썸네일이 1개 이상일 때만 노출되게 함 (0개면 글만 보이게)

| 썸네일 개수 | 사진 |
|:---:|:---:|
| 0개 | ![zero](https://github.com/user-attachments/assets/36fbbf8e-69f6-40b4-8b03-55b923350504) |
| 1개~4개 | ![under 5](https://github.com/user-attachments/assets/026542f0-0677-48d7-bccc-b95682e7d895) |
| 5개 이상 | ![over 5](https://github.com/user-attachments/assets/f9222afa-c2dd-41b3-9014-395f6a850cd5) |

- 상수명 수정 (`B`가 빠져서 그거 넣음)

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
