### PR TITLE
fix: 상세페이지 이미지 버튼이 안 보이는 문제

### DIFF
--- a/src/drawer/components/ServiceDetailContents/Carousel/Carousel.style.ts
+++ b/src/drawer/components/ServiceDetailContents/Carousel/Carousel.style.ts
@@ -27,7 +27,7 @@ interface StyledCarouselButtonProps {
   $right?: string;
 }
 
-export const StyledCarouselButton = styled.img<StyledCarouselButtonProps>`
+export const StyledCarouselButton = styled.button<StyledCarouselButtonProps>`
   width: 3rem;
   height: 3rem;
 
@@ -36,7 +36,9 @@ export const StyledCarouselButton = styled.img<StyledCarouselButtonProps>`
   left: ${(props) => props.$left && props.$left};
   right: ${(props) => props.$right && props.$right};
 
-  border: none;
-  border-radius: 24px;
-  cursor: pointer;
+  border-radius: 1.5rem;
+
+  img {
+    pointer-events: none;
+  }
 `;

--- a/src/drawer/components/ServiceDetailContents/Carousel/Carousel.style.ts
+++ b/src/drawer/components/ServiceDetailContents/Carousel/Carousel.style.ts
@@ -23,15 +23,11 @@ export const StyledCarousel = styled.div`
 `;
 
 interface StyledCarouselButtonProps {
-  $backgroundImage: string;
   $left?: string;
   $right?: string;
 }
 
-export const StyledCarouselButton = styled.input<StyledCarouselButtonProps>`
-  background-image: url(${(props) => props.$backgroundImage});
-  background-color: transparent;
-
+export const StyledCarouselButton = styled.img<StyledCarouselButtonProps>`
   width: 3rem;
   height: 3rem;
 

--- a/src/drawer/components/ServiceDetailContents/Carousel/Carousel.tsx
+++ b/src/drawer/components/ServiceDetailContents/Carousel/Carousel.tsx
@@ -15,7 +15,7 @@ export const Carousel = ({ introductionImage }: Pick<ProductDetailResult, 'intro
 
     if (scrollRef.current) {
       const x = scrollRef.current!.scrollLeft;
-      const scrollDirection = target.name === 'left' ? -scrollAmount : scrollAmount;
+      const scrollDirection = target.dataset.direction === 'left' ? -scrollAmount : scrollAmount;
 
       scrollRef.current.scrollTo(x + scrollDirection, 0);
     }
@@ -26,17 +26,15 @@ export const Carousel = ({ introductionImage }: Pick<ProductDetailResult, 'intro
       {introductionImage.length > 1 && (
         <>
           <StyledCarouselButton
-            $backgroundImage={carouselLeftButton}
+            src={carouselLeftButton}
             $left={'-24px'}
-            type="button"
-            name="left"
+            data-direction="left"
             onClick={handleCarouselClick}
           />
           <StyledCarouselButton
-            $backgroundImage={carouselRightButton}
+            src={carouselRightButton}
             $right={'-24px'}
-            type="button"
-            name="right"
+            data-direction="right"
             onClick={handleCarouselClick}
           />
         </>

--- a/src/drawer/components/ServiceDetailContents/Carousel/Carousel.tsx
+++ b/src/drawer/components/ServiceDetailContents/Carousel/Carousel.tsx
@@ -26,17 +26,21 @@ export const Carousel = ({ introductionImage }: Pick<ProductDetailResult, 'intro
       {introductionImage.length > 1 && (
         <>
           <StyledCarouselButton
-            src={carouselLeftButton}
             $left={'-24px'}
             data-direction="left"
             onClick={handleCarouselClick}
-          />
+            title={'carousel-left-button'}
+          >
+            <img src={carouselLeftButton} alt={'carousel-left-img'} />
+          </StyledCarouselButton>
           <StyledCarouselButton
-            src={carouselRightButton}
             $right={'-24px'}
             data-direction="right"
             onClick={handleCarouselClick}
-          />
+            title={'carousel-right-button'}
+          >
+            <img src={carouselRightButton} alt={'carousel-right-img'} />
+          </StyledCarouselButton>
         </>
       )}
       {introductionImage.map((imageSrc) => (

--- a/src/drawer/components/ServiceDetailContents/Description/Description.tsx
+++ b/src/drawer/components/ServiceDetailContents/Description/Description.tsx
@@ -15,7 +15,7 @@ export const Description = ({ product }: { product: ProductDetailResult }) => {
     <StyledDescriptionSection>
       <Carousel introductionImage={product.introductionImage} />
       <StyledDescriptionPart>
-        <StyledSubtitle>{`추천`}</StyledSubtitle>
+        <StyledSubtitle>{`즐겨찾기 수`}</StyledSubtitle>
         <StyledDescription>
           {product.count}+
           <IcStarFilled size={'15px'} color={'#FDD655'} />

--- a/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.style.ts
+++ b/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.style.ts
@@ -12,14 +12,7 @@ export const StyledMoreProductSection = styled.div`
   color: ${({ theme }) => theme.color.textPrimary};
 `;
 
-interface StyledArrowButtonProps {
-  $backgroundImage: string;
-}
-
-export const StyledArrowButton = styled.input<StyledArrowButtonProps>`
-  background-image: url(${(props) => props.$backgroundImage});
-  background-color: transparent;
-
+export const StyledArrowButton = styled.img`
   width: 3rem;
   height: 3rem;
   margin-left: 0.625rem;

--- a/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.style.ts
+++ b/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.style.ts
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const StyledMoreProductSection = styled.div`
@@ -12,13 +13,10 @@ export const StyledMoreProductSection = styled.div`
   color: ${({ theme }) => theme.color.textPrimary};
 `;
 
-export const StyledArrowButton = styled.img`
+export const StyledLink = styled(Link)`
   width: 3rem;
   height: 3rem;
   margin-left: 0.625rem;
-
-  border: none;
-  cursor: pointer;
 `;
 
 export const StyledContainer = styled.div`

--- a/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.tsx
+++ b/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.tsx
@@ -1,32 +1,21 @@
-import { useNavigate } from 'react-router-dom';
-
 import IcRightArrow from '@/drawer/assets/ic_right_arrow.svg';
 import { SmallDrawerCard } from '@/drawer/components/DrawerCard/SmallDrawerCard';
 import { useGetProductByProvider } from '@/drawer/hooks/useGetProductByProvider';
 
-import {
-  StyledArrowButton,
-  StyledContainer,
-  StyledMoreProductSection,
-} from './MoreProductSection.style';
+import { StyledContainer, StyledLink, StyledMoreProductSection } from './MoreProductSection.style';
 
 export const MoreProductSection = ({ providerId }: { providerId: string }) => {
   const { data } = useGetProductByProvider({ providerId });
   const { providerName, products } = data.pages[0];
-
-  const navigate = useNavigate();
 
   if (products.length === 0) return null;
   return (
     <StyledMoreProductSection>
       <StyledContainer>
         {providerName}의 서비스 더보기
-        <StyledArrowButton
-          src={IcRightArrow}
-          onClick={() => {
-            navigate(`/drawer/${providerId}`);
-          }}
-        />
+        <StyledLink to={`/drawer/${providerId}`} title={'more-production-link'}>
+          <img src={IcRightArrow} alt={'right-arrow-icon'} />
+        </StyledLink>
       </StyledContainer>
       {products.slice(0, 5).map(({ productTitle, count, productNo, mainImage, isBookmarked }) => (
         <SmallDrawerCard

--- a/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.tsx
+++ b/src/drawer/components/ServiceDetailContents/MoreProductSection/MoreProductSection.tsx
@@ -22,8 +22,7 @@ export const MoreProductSection = ({ providerId }: { providerId: string }) => {
       <StyledContainer>
         {providerName}의 서비스 더보기
         <StyledArrowButton
-          $backgroundImage={IcRightArrow}
-          type="button"
+          src={IcRightArrow}
           onClick={() => {
             navigate(`/drawer/${providerId}`);
           }}

--- a/src/drawer/components/ServiceDetailContents/ServiceAction/ServiceAction.tsx
+++ b/src/drawer/components/ServiceDetailContents/ServiceAction/ServiceAction.tsx
@@ -111,7 +111,7 @@ export const ServiceAction = ({ product }: { product: ProductDetailResult }) => 
               {product.isBookmarked ? <IcStarFilled /> : <IcStarLine />}
             </IconContext.Provider>
           </button>
-          <StyledIconLabelText $color={theme.color.pointYellow}>Recommend</StyledIconLabelText>
+          <StyledIconLabelText $color={theme.color.pointYellow}>Bookmark</StyledIconLabelText>
         </StyledIconButtonContainer>
       </StyledServiceActionContainer>
       {isShowToast && <Toast {...toastProps} />}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #279
- resolved #274

두 이슈가 동일한 원인이라 한 브랜치에서 모두 수정했습니다

### 기존 코드에 영향을 미치지 않는 변경사항

- 상세페이지의 추천 관련 워딩이 수정되었습니다

  스레드에 웹팀 언급이 없어서 오늘 확인했는데! 딱 두 줄 고치는거라 그냥 여기 끼워뒀어요

  [여기](https://yourssu.slack.com/archives/C06BWMEPPNV/p1724511831397999?thread_ts=1723530735.772469&channel=C06BWMEPPNV&message_ts=1724511831.397999) 보시면 됩니다

### 버그 픽스

- `input type=button`을 button/Link 내에`img` 태그가 있는 형태로 수정했습니다
- `Carousel`의 화살표 버튼에 넣어놨던 `name` prop은 방향 구분을 위해 임의로 넣은 값이라,
dataset을 이용하는 게 좀 더 의도를 드러내는 거 같아서 수정했습니다

<details>
<summary>왜 버튼이 안 보였는지 적어둔 토글인데요 ^^... 사실 다 못찾았어요</summary>
<div markdown="1">
<br/>
1. `input type="button"` 요소에서 스타일 아예 안 들어가고 있었음

  | localhost | build result |
  |:---:|:---:|
  | ![image](https://github.com/user-attachments/assets/5f9d2b01-960e-4061-bf18-a73e0eb331ed) | ![image](https://github.com/user-attachments/assets/3dd7218c-7ec4-4abe-9f66-b0fc491e746c) |
  | 로컬에선 잘 됐는데 | 빌드하면... 텅텅 비었음.. |

2. `styled.input`을 `styled.input.attrs({ type: 'button' })`으로 수정하면 스타일이 먹히긴 하는데

3. `url(value)`에서 svg 파일 경로가 올바르게 되어있음에도 불구하고 이미지 로딩을 자꾸 못하더라고요... 

3번까지 갔다가 열받아서 img 태그로 수정했습니다 정확한 원인,, 곧 찾아서 정리해두겠습니다,,,
</div>
</details>

---

`pnpm preview`로 빌드 환경에서 이미지 보이는지 확인한 사진입니당

![preview](https://github.com/user-attachments/assets/773543b5-dfa3-4214-a859-2e1c4ca35df8)


## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
