### PR TITLE
fix: 서랍장 검색 결과가 없을 때 서비스 등록하기를 클릭해도 페이지가 안넘어가짐

### DIFF
--- a/src/drawer/components/EmptyScreen/EmptyScreen.tsx
+++ b/src/drawer/components/EmptyScreen/EmptyScreen.tsx
@@ -1,7 +1,11 @@
 import { BoxButton } from '@yourssu/design-system-react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import NotIllust from '@/drawer/assets/noResultDrawer.png';
 import { NOT_FOUND_TEXT } from '@/drawer/constants/empty.constant';
+import { LogInState } from '@/home/recoil/LogInState';
+import { DialogState } from '@/recoil/DialogState';
 
 import {
   StyledNotContainer,
@@ -17,16 +21,34 @@ interface EmptyScreenProps {
 export const EmptyScreen = ({ type }: EmptyScreenProps) => {
   const { boldText, subText } = NOT_FOUND_TEXT[type];
 
+  const setDialog = useSetRecoilState(DialogState);
+  const isLoggedIn = useRecoilValue(LogInState);
+  const navigate = useNavigate();
+
+  const handleClickButton = () => {
+    if (isLoggedIn) {
+      navigate('/drawer/register');
+      return;
+    }
+    setDialog({ open: true, type: 'login' });
+  };
+
   return (
     <StyledNotContainer>
       <StyledNotTextContainer>
         <StyledNotTextBold>{boldText}</StyledNotTextBold>
         <div>{subText}</div>
       </StyledNotTextContainer>
-      <StyledNotImg src={NotIllust} />
+      <StyledNotImg src={NotIllust} alt="no-result-ppussung" />
 
       {(type === 'SEARCH' || type === 'MYDRAWER') && (
-        <BoxButton size="small" variant="filled" rounding={4}>
+        <BoxButton
+          size="small"
+          variant="filled"
+          rounding={4}
+          type="button"
+          onClick={handleClickButton}
+        >
           서비스 등록하기
         </BoxButton>
       )}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #275

### 기존 코드에 영향을 미치지 않는 변경사항

- 서랍장 검색 결과 없을 때
- `서비스 등록하기` 버튼 핸들러가 없어서 클릭해도 딱히 반응을 안 하고 있었음
- `handleClickButton`을 추가함

  - 로그인 했으면 `서비스 등록` 페이지로 이동
  - 로그인 안 했으면 다이얼로그 뜸

| 로그인 O | 로그인 X | 
|:---:|:---:|
|![logged](https://github.com/user-attachments/assets/1e19f51f-5c23-43ef-8762-7ef8a90cdb41)|![nonlogged](https://github.com/user-attachments/assets/fd25b77d-fd99-4006-92a3-fdf7bb26ff58)|

## 2️⃣ 알아두시면 좋아요!

이거 원래 체리가 하기로 되어있었는데

제가 깃헙 이슈칸에 담당자 없는 것만 보고.............. 남은 작업이라 착각해서 작업한 뒤에 노션을 봐버렸어요

이제부터 노션부터 확인할게요 죄송합니다 ㅠㅠ!!!!!!!!!! @seocylucky 

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
