### PR TITLE
fix: 검색 결과가 없는 경우 요청 및 편집 섹션을 클릭하면 해당 링크로 이동하도록 수정

### DIFF
--- a/src/search/pages/NoResult/NoResult.style.ts
+++ b/src/search/pages/NoResult/NoResult.style.ts
@@ -45,7 +45,7 @@ export const StyledCard = styled.div`
 
   cursor: pointer;
 
-  &: hover {
+  &:hover {
     text-decoration: underline;
   }
 `;

--- a/src/search/pages/NoResult/NoResult.style.ts
+++ b/src/search/pages/NoResult/NoResult.style.ts
@@ -10,20 +10,13 @@ export const StyledContainer = styled.div`
 `;
 
 export const StyledNoResultKeyword = styled.span`
-  color: ${({ theme }) => theme.color.textPointed};
-
   ${({ theme }) => theme.typo.title2}
+  color: ${({ theme }) => theme.color.textPointed};
 `;
 
 export const StyledNoResultDescription = styled.p`
+  ${({ theme }) => theme.typo.subtitle2}
   color: ${({ theme }) => theme.color.textPrimary};
-
-  /* PC & Android/subtitle24 */
-  font-family: 'Spoqa Han Sans Neo';
-  font-size: 1.5rem;
-  font-style: normal;
-  font-weight: 500;
-  line-height: 130%; /* 1.95rem */
 `;
 
 export const StyledModifySection = styled.div`
@@ -33,14 +26,8 @@ export const StyledModifySection = styled.div`
 `;
 
 export const StyledModifyDescription = styled.p`
+  ${({ theme }) => theme.typo.body1}
   color: ${({ theme }) => theme.color.textTertiary};
-
-  /* PC & Android/body18 */
-  font-family: 'Spoqa Han Sans Neo';
-  font-size: 1.125rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
 `;
 
 export const StyledCard = styled.div`
@@ -55,6 +42,12 @@ export const StyledCard = styled.div`
   border-radius: 0.75rem;
   border: 1px solid ${({ theme }) => theme.color.borderNormal};
   background: ${({ theme }) => theme.color.bgNormal};
+
+  cursor: pointer;
+
+  &: hover {
+    text-decoration: underline;
+  }
 `;
 
 export const StyledCardDescriptionSection = styled.div`
@@ -63,7 +56,7 @@ export const StyledCardDescriptionSection = styled.div`
 `;
 
 interface StyledCardIconFrameProp {
-  $index: number;
+  $type: 'request' | 'edit';
 }
 
 export const StyledCardIconFrame = styled.div<StyledCardIconFrameProp>`
@@ -74,7 +67,7 @@ export const StyledCardIconFrame = styled.div<StyledCardIconFrameProp>`
   justify-content: center;
   align-items: center;
   border-radius: 0.5rem;
-  background: ${(prop) => (prop.$index === 0 ? 'rgba(255, 44, 190, 0.1)' : '#ebe6fb')};
+  background: ${({ $type }) => ($type === 'request' ? 'rgba(255, 44, 190, 0.1)' : '#ebe6fb')};
 `;
 
 export const StyledCardTextFrame = styled.div`
@@ -84,25 +77,12 @@ export const StyledCardTextFrame = styled.div`
   gap: 0.25rem;
 `;
 
-export const StyledCardLinkText = styled.a`
+export const StyledCardTitle = styled.span`
+  ${({ theme }) => theme.typo.subtitle3}
   color: ${({ theme }) => theme.color.textPrimary};
-
-  ${({ theme }) => theme.typo.subtitle1}
-
-  &:hover {
-    color: ${({ theme }) => theme.color.textPrimary};
-    text-decoration: underline;
-    cursor: pointer;
-  }
 `;
 
-export const StyledCardLinkTextDescription = styled.p`
+export const StyledCardDescription = styled.p`
+  ${({ theme }) => theme.typo.body2}
   color: ${({ theme }) => theme.color.textTertiary};
-
-  /* PC & Android/body16 */
-  font-family: 'Spoqa Han Sans Neo';
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 130%; /* 1.3rem */
 `;

--- a/src/search/pages/NoResult/NoResult.tsx
+++ b/src/search/pages/NoResult/NoResult.tsx
@@ -42,9 +42,9 @@ export const NoResult = () => {
 
   const handleClickAddSection = (type: 'request' | 'edit') => {
     if (type === 'request') {
-      window.open(ADD_SECTION_DATA[0].url, '_blank');
+      window.open(ADD_SECTION_DATA[0].url);
     } else {
-      window.open(ADD_SECTION_DATA[1].url(query), '_blank');
+      window.open(ADD_SECTION_DATA[1].url(query));
     }
   };
 

--- a/src/search/pages/NoResult/NoResult.tsx
+++ b/src/search/pages/NoResult/NoResult.tsx
@@ -1,124 +1,80 @@
-import { useEffect, useState } from 'react';
-
-import { IcArrowRightLine, IcPenLine, IconContext } from '@yourssu/design-system-react';
+import { IcArrowRightLine, IcPenLine } from '@yourssu/design-system-react';
+import { useSearchParams } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 
 import IcSoomsilde from '@/assets/ic_wiki.svg';
 import { FlexContainer } from '@/components/FlexContainer/FlexContainer';
 
 import {
-  StyledModifySection,
-  StyledModifyDescription,
-  StyledNoResultKeyword,
-  StyledNoResultDescription,
-  StyledContainer,
   StyledCard,
-  StyledCardIconFrame,
+  StyledCardDescription,
   StyledCardDescriptionSection,
+  StyledCardIconFrame,
   StyledCardTextFrame,
-  StyledCardLinkTextDescription,
-  StyledCardLinkText,
+  StyledCardTitle,
+  StyledContainer,
+  StyledModifyDescription,
+  StyledModifySection,
+  StyledNoResultDescription,
+  StyledNoResultKeyword,
 } from './NoResult.style';
 
-interface AddSectionData {
-  linkText: string;
-  linkTextDescription: string;
-  href: string;
-}
-
-const ADD_SECTION_DATA: AddSectionData[] = [
+const ADD_SECTION_DATA = [
   {
-    linkText: '숨쉴위키에 내용 추가 요청하기',
-    linkTextDescription: '해당 검색어에 대해 궁금하다면 추가를 요청해보세요',
-    href: `https://forms.gle/YruucE1ZkTBtc6YE8`,
+    type: 'request',
+    title: '숨쉴위키에 내용 추가 요청하기',
+    description: '해당 검색어에 대해 궁금하다면 추가를 요청해보세요',
+    url: `https://forms.gle/YruucE1ZkTBtc6YE8`,
   },
   {
-    linkText: '숨쉴위키에서 편집하기',
-    linkTextDescription: '이미 알고 있는 내용이라면 숨쉴위키에 내용을 추가해주세요',
-    href: `https://wiki.soomsil.de/wiki/index.php?title={query}&action=edit`,
+    type: 'edit',
+    title: '숨쉴위키에서 편집하기',
+    description: '이미 알고 있는 내용이라면 숨쉴위키에 내용을 추가해주세요',
+    url: (query: string) => `https://wiki.soomsil.de/wiki/index.php?title=${query}&action=edit`,
   },
-];
+] as const;
 
 export const NoResult = () => {
   const theme = useTheme();
+  const [searchParams] = useSearchParams();
 
-  const [noResultKeyword, setNoResultKeyword] = useState<string>();
-  const [addSectionData, setAddSectionData] = useState<AddSectionData[]>();
+  const query = searchParams.get('query') ?? '';
 
-  useEffect(() => {
-    const currentURL = window.location.href;
-    const queryParams = new URLSearchParams(new URL(currentURL).search);
-    const queryValue = queryParams.get('query');
-    if (queryValue) {
-      setNoResultKeyword(queryValue);
+  const handleClickAddSection = (type: 'request' | 'edit') => {
+    if (type === 'request') {
+      window.open(ADD_SECTION_DATA[0].url, '_blank');
+    } else {
+      window.open(ADD_SECTION_DATA[1].url(query), '_blank');
     }
-  }, []);
-
-  useEffect(() => {
-    if (noResultKeyword) {
-      setAddSectionData(
-        ADD_SECTION_DATA.map((data) => ({
-          ...data,
-          href: data.href.replace('{query}', encodeURIComponent(noResultKeyword)),
-        }))
-      );
-    }
-  }, [noResultKeyword]);
+  };
 
   return (
     <StyledContainer>
       <FlexContainer>
-        <StyledNoResultKeyword>'{noResultKeyword}'</StyledNoResultKeyword>
+        <StyledNoResultKeyword>'{query}'</StyledNoResultKeyword>
         <StyledNoResultDescription>에 대한 검색결과가 없습니다.</StyledNoResultDescription>
       </FlexContainer>
       <StyledModifySection>
         <StyledModifyDescription>
           찾으시는 검색결과가 없다면 아래 기능을 사용해보세요
         </StyledModifyDescription>
-        {addSectionData?.map((value, index) => {
+        {ADD_SECTION_DATA.map((section) => {
           return (
-            <StyledCard key={value.linkText}>
+            <StyledCard key={section.type} onClick={() => handleClickAddSection(section.type)}>
               <StyledCardDescriptionSection>
-                <StyledCardIconFrame $index={index}>
-                  {index === 0 ? (
+                <StyledCardIconFrame $type={section.type}>
+                  {section.type === 'request' ? (
                     <img src={IcSoomsilde} alt="soomsil" />
                   ) : (
-                    <IconContext.Provider
-                      value={{
-                        size: '1.8rem',
-                        color: theme.color.buttonPoint,
-                      }}
-                    >
-                      <IcPenLine />
-                    </IconContext.Provider>
+                    <IcPenLine size="1.8rem" color={theme.color.buttonPoint} />
                   )}
                 </StyledCardIconFrame>
                 <StyledCardTextFrame>
-                  <StyledCardLinkText
-                    onClick={() => {
-                      window.open(value.href);
-                    }}
-                  >
-                    {value.linkText}
-                  </StyledCardLinkText>
-                  <StyledCardLinkTextDescription>
-                    {value.linkTextDescription}
-                  </StyledCardLinkTextDescription>
+                  <StyledCardTitle>{section.title}</StyledCardTitle>
+                  <StyledCardDescription>{section.description}</StyledCardDescription>
                 </StyledCardTextFrame>
               </StyledCardDescriptionSection>
-              <IconContext.Provider
-                value={{
-                  size: '1.2rem',
-                  color: theme.color.buttonNormal,
-                  cursor: 'pointer',
-                }}
-              >
-                <IcArrowRightLine
-                  onClick={() => {
-                    window.open(value.href);
-                  }}
-                />
-              </IconContext.Provider>
+              <IcArrowRightLine size="1.2rem" color={theme.color.buttonNormal} />
             </StyledCard>
           );
         })}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)


https://github.com/user-attachments/assets/970d44f0-dd20-4e3d-a1d4-c5833ca09b00


- resolved #281 

### 기존 코드에 영향을 미치는 변경사항
- `src/search/pages/NoResult/NoResult.tsx`
  - 기존의 [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)를 이용하여 Search Param을 취득하는 부분을 React Router의 [useSearchParams()](https://reactrouter.com/en/main/hooks/use-search-params) 훅을 사용하여 리팩토링 했습니다.
  - 요청 및 편집 섹션을 클릭하면 링크 이동이 이루어지기 때문에 텍스트나 아이콘 네이밍에 `link`를 제거하였습니다.
- `src/search/pages/NoResult/NoResult.style.ts`
  - 피그마에서 사용되던 커스텀 폰트를 같은 스타일의 YDS 폰트로 교체하였습니다.

## 2️⃣ 알아두시면 좋아요!
피그마에 '검색 결과 없을 시 화면'에 네이버를 참고하라는 사항이 있어 네이버 디자인을 참고하여 카드에 마우스 호버시 카드 아래 모든 텍스트에  `underline` 효과를 주도록 하였습니다.

<img width="304" alt="스크린샷 2024-08-25 오전 3 39 54" src="https://github.com/user-attachments/assets/2f30b73b-4a74-43a9-93ca-cef9b1a456d5">

- 네이버 '검색 결과 없을 시 화면'
<img width="372" alt="스크린샷 2024-08-25 오전 3 41 57" src="https://github.com/user-attachments/assets/918dfa3b-65ef-4fde-b8c4-48fe7b087a72">

## 3️⃣ 추후 작업
- 리뷰 반영하기

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
