### PR TITLE
fix: 검색어가 너무 길면 줄바꿈 안 되는 문제

### DIFF
--- a/src/search/pages/NoResult/NoResult.style.ts
+++ b/src/search/pages/NoResult/NoResult.style.ts
@@ -26,6 +26,9 @@ export const StyledNoResultDescription = styled.p`
   font-style: normal;
   font-weight: 500;
   line-height: 130%; /* 1.95rem */
+
+  display: inline;
+  white-space: nowrap;
 `;
 
 export const StyledModifySection = styled.div`

--- a/src/search/pages/NoResult/NoResult.style.ts
+++ b/src/search/pages/NoResult/NoResult.style.ts
@@ -10,6 +10,8 @@ export const StyledContainer = styled.div`
 `;
 
 export const StyledNoResultKeyword = styled.span`
+  word-break: break-all;
+  overflow-wrap: break-word;
   color: ${({ theme }) => theme.color.textPointed};
 
   ${({ theme }) => theme.typo.title2}

--- a/src/search/pages/NoResult/NoResult.style.ts
+++ b/src/search/pages/NoResult/NoResult.style.ts
@@ -27,8 +27,7 @@ export const StyledNoResultDescription = styled.p`
   font-weight: 500;
   line-height: 130%; /* 1.95rem */
 
-  display: inline;
-  white-space: nowrap;
+  display: inline-block;
 `;
 
 export const StyledModifySection = styled.div`

--- a/src/search/pages/NoResult/NoResult.tsx
+++ b/src/search/pages/NoResult/NoResult.tsx
@@ -7,17 +7,17 @@ import IcSoomsilde from '@/assets/ic_wiki.svg';
 import { FlexContainer } from '@/components/FlexContainer/FlexContainer';
 
 import {
-  StyledModifySection,
-  StyledModifyDescription,
-  StyledNoResultKeyword,
-  StyledNoResultDescription,
-  StyledContainer,
   StyledCard,
-  StyledCardIconFrame,
   StyledCardDescriptionSection,
-  StyledCardTextFrame,
-  StyledCardLinkTextDescription,
+  StyledCardIconFrame,
   StyledCardLinkText,
+  StyledCardLinkTextDescription,
+  StyledCardTextFrame,
+  StyledContainer,
+  StyledModifyDescription,
+  StyledModifySection,
+  StyledNoResultDescription,
+  StyledNoResultKeyword,
 } from './NoResult.style';
 
 interface AddSectionData {

--- a/src/search/pages/NoResult/NoResult.tsx
+++ b/src/search/pages/NoResult/NoResult.tsx
@@ -68,8 +68,10 @@ export const NoResult = () => {
   return (
     <StyledContainer>
       <FlexContainer>
-        <StyledNoResultKeyword>'{noResultKeyword}'</StyledNoResultKeyword>
-        <StyledNoResultDescription>에 대한 검색결과가 없습니다.</StyledNoResultDescription>
+        <div>
+          <StyledNoResultKeyword>'{noResultKeyword}'</StyledNoResultKeyword>
+          <StyledNoResultDescription>에 대한 검색결과가 없습니다.</StyledNoResultDescription>
+        </div>
       </FlexContainer>
       <StyledModifySection>
         <StyledModifyDescription>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

<img width="1088" alt="스크린샷 2024-08-28 오후 7 07 17" src="https://github.com/user-attachments/assets/02bbb1cd-eeb0-41c2-94ce-555464c13389">
<img width="1083" alt="스크린샷 2024-08-28 오후 7 07 25" src="https://github.com/user-attachments/assets/3d3ba49d-1ac1-45ce-98bd-17b54544b51f">

- 줄바꿈 스타일을 추가했습니다. (8/28 오후 8시 수정했습니당)

> 생각해보니까 멘트를 검색어 아래로 내리는 게 보기 더 좋을 것 같네요

라는 제롬의 의견 반영하였습니다.

- `StyledNoResultKeyword`
  - `word-break: break-all;` + `overflow-wrap: break-word;`
  - 검색어가 길어도 컨테이너를 넘지 않도록 단어를 중간에서 끊어주는 역할

- `StyledNoResultDescription` 
  - `display: inline;` + `white-space: nowrap;`
  -  inline을 해줘서 글자 수가 적을 때는 한 줄에 나오도록 + ‘에 대한 검색결과가 없습니다.’ 자체는 줄바꿈이 안되게 유지

- `div`
  - 두 개를 묶어줘야 하더라구여,,,

- resolved #277 

### 버그 픽스

## 2️⃣ 알아두시면 좋아요!
<img width="714" alt="스크린샷 2024-08-28 오전 1 48 53" src="https://github.com/user-attachments/assets/cee1cc05-1b3e-41c6-9a2e-f83258dba86b">

- 너무... 달랑 넣은 것 같아서 참고를 [조금](https://smartstudio.tech/deepdive-linebreak-css-about-language/) 해봤습니다... 이렇다네요...

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
