### PR TITLE
fix: sns 버튼이 새탭으로 열리지 않는 문제 수정

### DIFF
--- a/src/home/components/SocialNetworkService/SocialNetworkService.tsx
+++ b/src/home/components/SocialNetworkService/SocialNetworkService.tsx
@@ -4,7 +4,7 @@ import BlogIcon from '@/assets/home/blog.svg';
 import BrunchIcon from '@/assets/home/brunch.svg';
 import InstagramIcon from '@/assets/home/instagram.svg';
 import PpussungIcon from '@/assets/home/ppussung.svg';
-import { QuickLink } from '@/home/components/QuickLink/QuickLink.tsx';
+import { QuickLink } from '@/home/components/QuickLink/QuickLink';
 
 import { StyledIcon, StyledIconContainer, StyledLine } from './SocialNetworkService.style';
 
@@ -25,7 +25,7 @@ export const SocialNetworkService = () => {
         {ICON_LIST.map((icon, index) => (
           <React.Fragment key={icon.icon}>
             <QuickLink icon={icon} order={String(index + 1)}>
-              <StyledIcon to={icon.link} $image={icon.icon} />
+              <StyledIcon to={icon.link} $image={icon.icon} target="_blank" />
             </QuickLink>
             {ICON_LIST.length !== index + 1 && <StyledLine />}
           </React.Fragment>


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

<img width="93" alt="image" src="https://github.com/user-attachments/assets/ace84168-a432-48c4-8468-ea76f32a954e">

`SocialNetworkService` 컴포넌트의 링크들이 새 탭이 아니라 현재 페이지에서 라우팅되는 문제를 수정했습니다.

- resolved #263

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

### 버그 픽스

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
