### PR TITLE
fix: 사이트 이름 클릭 시 사이트로 이동하게 수정

### DIFF
--- a/src/search/components/ResultList/ResultList.tsx
+++ b/src/search/components/ResultList/ResultList.tsx
@@ -32,12 +32,22 @@ export const ResultList = () => {
   const { data: currentUser } = useGetUserData();
   const userId = currentUser?.email || '';
 
+  const handleExtractDomain = (url: string) => {
+    try {
+      const { origin } = new URL(url);
+      return origin;
+    } catch (error) {
+      return url;
+    }
+  };
+
   return (
     <NoResultFallback results={data?.pages[0].resultList} fallback={<NoResult />}>
       <Suspense fallback={<Loading />}>
         {data?.pages.map((page) => {
           return page.resultList.map((item, itemIndex) => {
             const isLastItem = page.resultList.length === itemIndex + 1;
+            const domain = handleExtractDomain(item.link);
             return (
               <div key={item.id}>
                 <LogClick
@@ -59,6 +69,7 @@ export const ResultList = () => {
                 >
                   <ResultListItem
                     {...item}
+                    domain={domain}
                     onClick={() => window.open(item.link)}
                     ref={isLastItem ? lastElementRef : null}
                   />

--- a/src/search/components/ResultList/ResultList.tsx
+++ b/src/search/components/ResultList/ResultList.tsx
@@ -10,6 +10,7 @@ import { useScrollObserve } from '@/hooks/useScrollObserve';
 import { useGetSearch } from '@/search/hooks/useGetSearch';
 import { NoResult } from '@/search/pages/NoResult/NoResult';
 import { SearchResponse } from '@/search/types/ResultListItem.type';
+import { extractOrigin } from '@/search/utils/extractOrigin';
 
 import NoResultFallback from '../FallbackComponent/NoResultFallback';
 
@@ -32,22 +33,13 @@ export const ResultList = () => {
   const { data: currentUser } = useGetUserData();
   const userId = currentUser?.email || '';
 
-  const handleExtractDomain = (url: string) => {
-    try {
-      const { origin } = new URL(url);
-      return origin;
-    } catch (error) {
-      return url;
-    }
-  };
-
   return (
     <NoResultFallback results={data?.pages[0].resultList} fallback={<NoResult />}>
       <Suspense fallback={<Loading />}>
         {data?.pages.map((page) => {
           return page.resultList.map((item, itemIndex) => {
             const isLastItem = page.resultList.length === itemIndex + 1;
-            const domain = handleExtractDomain(item.link);
+            const domain = extractOrigin(item.link);
             return (
               <div key={item.id}>
                 <LogClick

--- a/src/search/components/ResultList/ResultListItem.style.ts
+++ b/src/search/components/ResultList/ResultListItem.style.ts
@@ -47,6 +47,17 @@ export const StyledLinkImage = styled.img`
 export const StyledLinkTitle = styled.span`
   ${(props) => props.theme.typo.body1}
   color: ${(props) => props.theme.color.textSecondary};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const StyledDomain = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 `;
 
 export const StyledDate = styled.span`

--- a/src/search/components/ResultList/ResultListItem.tsx
+++ b/src/search/components/ResultList/ResultListItem.tsx
@@ -17,23 +17,35 @@ import {
   StyledTitle,
   StyledContentWrap,
   StyledInformationWrap,
+  StyledDomain,
 } from './ResultListItem.style';
 
 interface ResultListItemProps
   extends Pick<React.ComponentProps<'div'>, 'onClick'>,
-    ResultListItemResponse {}
+    ResultListItemResponse {
+  domain?: string;
+}
 
 export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
-  ({ title, content, date, thumbnail, favicon, source, onClick }, ref) => {
+  ({ title, content, date, thumbnail, favicon, source, domain, onClick }, ref) => {
+    const handleDomainClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (domain) {
+        window.open(domain, '_blank');
+      }
+    };
+
     return (
       <StyledResultListItem ref={ref} onClick={onClick}>
         <StyledContentWrap $length={thumbnail.length}>
           <StyledInformationWrap>
-            <StyledLinkImageWrap>
-              <StyledLinkImage src={favicon || '/'} alt="favicon" onError={onErrorImg} />
-            </StyledLinkImageWrap>
-            <Spacing direction="horizontal" size={4} />
-            <StyledLinkTitle>{source}</StyledLinkTitle>
+            <StyledDomain onClick={handleDomainClick}>
+              <StyledLinkImageWrap>
+                <StyledLinkImage src={favicon || '/'} alt="favicon" onError={onErrorImg} />
+              </StyledLinkImageWrap>
+              <Spacing direction="horizontal" size={4} />
+              <StyledLinkTitle>{source}</StyledLinkTitle>
+            </StyledDomain>
             <Spacing direction="horizontal" size={4} />
             <StyledDate>·</StyledDate>
             <Spacing direction="horizontal" size={4} />

--- a/src/search/components/ResultList/ResultListItem.tsx
+++ b/src/search/components/ResultList/ResultListItem.tsx
@@ -7,18 +7,18 @@ import { onErrorImg } from '@/search/utils/onErrorImg';
 
 import {
   StyledContent,
+  StyledContentWrap,
   StyledDate,
-  StyledLinkImageWrap,
+  StyledDomain,
+  StyledInformationWrap,
   StyledLinkImage,
+  StyledLinkImageWrap,
   StyledLinkTitle,
   StyledResultListItem,
   StyledThumbnail,
   StyledThumbnailCountBox,
   StyledThumbnailImage,
   StyledTitle,
-  StyledContentWrap,
-  StyledInformationWrap,
-  StyledDomain,
 } from './ResultListItem.style';
 
 interface ResultListItemProps
@@ -34,7 +34,7 @@ export const ResultListItem = forwardRef<HTMLDivElement, ResultListItemProps>(
     const handleDomainClick = (e: React.MouseEvent) => {
       e.stopPropagation();
       if (domain) {
-        window.open(domain, '_blank');
+        window.open(domain);
       }
     };
 

--- a/src/search/utils/extractOrigin.ts
+++ b/src/search/utils/extractOrigin.ts
@@ -1,0 +1,8 @@
+export const extractOrigin = (url: string): string => {
+  try {
+    const { origin } = new URL(url);
+    return origin;
+  } catch (error) {
+    return url;
+  }
+};


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

https://github.com/user-attachments/assets/6d3f5789-500f-430b-9cbd-f86d5b48b63f


- `handleExtractDomain` 함수는 서버에서 받아온 link ("link": "https://fun.ssu.ac.kr/ko/program/all/view/1584",)에서 상위 도메인만 추출하여 `ResultListItem` 컴포넌트로 보냅니다. 
  -  URL의 프로토콜의 상위 도메인을 반환하는 origin 속성을 사용하였습니다. [관련 문서](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin)
- `handleDomainClick` 함수는 도메인을 새 창에서 여는 역할을 합니다. `ResultListItem` 전체에 클릭 이벤트가 이미 적용되어 있기 때문에 이벤트 전파를 막아 `StyledDomain` 내에서만 상위 도메인 링크가 열리도록 하고 그 외의 영역에서는 기존에 전달된 링크가 열리도록 설정했습니다.
- 클릭이 되는 것이라는 걸(??) 알 수 있도록 마우스 호버시 underline이 생기게 하는 효과를 적용하였습니다.

- resolved #266 

## 2️⃣ 알아두시면 좋아요!
- 혹시 저렇게 상위 도메인을 추출하는 방법 말고 다른 방법이 있다면,,, 알려주세여
- 현재 서버에서 받아오는 링크가 펀시스템밖에 없는데 서버 오류인지 원래 그런건지 모르겠습니다

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [X] `main` 브랜치의 최신 코드를 `pull` 받았나요?
