### PR TITLE
fix: 서랍장 서비스 등록 시, 리다이렉트 URL myproduct로 이동

### DIFF
--- a/src/drawer/pages/Register/Register.tsx
+++ b/src/drawer/pages/Register/Register.tsx
@@ -65,7 +65,7 @@ export const Register = () => {
             window.Android.onRegisterSuccess();
           }
 
-          navigate('/drawer/myDrawers');
+          navigate('/drawer/myDrawers?tab=MYDRAWER');
         },
       });
     }


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #272 

![Aug-31-2024 17-10-47](https://github.com/user-attachments/assets/6e0755df-e9fa-45fe-a95a-cac57697e2a4)


### 기존 코드에 영향을 미치지 않는 변경사항

서비스 등록 시, `내 서랍장의 Stars가 아닌 My Products로 이동`할 수 있게 하였습니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
