### PR TITLE
fix: 랭킹 카테고리 결과 없는 경우 아무것도 안뜨는 상태

### DIFF
--- a/src/drawer/components/EmptyScreen/EmptyScreen.tsx
+++ b/src/drawer/components/EmptyScreen/EmptyScreen.tsx
@@ -15,7 +15,7 @@ import {
 } from './EmptyScreen.style';
 
 interface EmptyScreenProps {
-  type: 'SEARCH' | 'STAR' | 'MYDRAWER' | 'PROVIDER';
+  type: 'SEARCH' | 'STAR' | 'MYDRAWER' | 'PROVIDER' | 'CATEGORY';
 }
 
 export const EmptyScreen = ({ type }: EmptyScreenProps) => {

--- a/src/drawer/components/EmptyScreen/EmptyScreen.tsx
+++ b/src/drawer/components/EmptyScreen/EmptyScreen.tsx
@@ -15,7 +15,7 @@ import {
 } from './EmptyScreen.style';
 
 interface EmptyScreenProps {
-  type: 'SEARCH' | 'STAR' | 'MYDRAWER' | 'PROVIDER' | 'CATEGORY';
+  type: 'SEARCH' | 'STAR' | 'MYDRAWER' | 'CATEGORY';
 }
 
 export const EmptyScreen = ({ type }: EmptyScreenProps) => {

--- a/src/drawer/components/EmptyScreen/EmptyScreen.tsx
+++ b/src/drawer/components/EmptyScreen/EmptyScreen.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import NotIllust from '@/drawer/assets/noResultDrawer.png';
 import { NOT_FOUND_TEXT } from '@/drawer/constants/empty.constant';
+import { EmptyStateType } from '@/drawer/types/emptyState.type';
 import { LogInState } from '@/home/recoil/LogInState';
 import { DialogState } from '@/recoil/DialogState';
 
@@ -14,11 +15,7 @@ import {
   StyledNotTextContainer,
 } from './EmptyScreen.style';
 
-interface EmptyScreenProps {
-  type: 'SEARCH' | 'STAR' | 'MYDRAWER' | 'CATEGORY';
-}
-
-export const EmptyScreen = ({ type }: EmptyScreenProps) => {
+export const EmptyScreen = ({ type }: { type: EmptyStateType }) => {
   const { boldText, subText } = NOT_FOUND_TEXT[type];
 
   const setDialog = useSetRecoilState(DialogState);

--- a/src/drawer/constants/empty.constant.ts
+++ b/src/drawer/constants/empty.constant.ts
@@ -1,4 +1,4 @@
-import { EmptyStateType } from '../types/emptyState.type';
+import { EmptyStateType } from '@/drawer/types/emptyState.type';
 
 export const NOT_FOUND_TEXT: Record<EmptyStateType, { boldText: string; subText: string }> = {
   SEARCH: {

--- a/src/drawer/constants/empty.constant.ts
+++ b/src/drawer/constants/empty.constant.ts
@@ -15,7 +15,7 @@ export const NOT_FOUND_TEXT: Record<
     subText: '새로운 서비스를 등록해보세요.',
   },
   PROVIDER: {
-    boldText: '아직 해당 카테고리에 업로드한 서비스가 없습니다.',
-    subText: '',
+    boldText: '현재 해당 카테고리에 등록된 서비스가 없습니다.',
+    subText: '다른 카테고리를 확인해보세요!',
   },
 };

--- a/src/drawer/constants/empty.constant.ts
+++ b/src/drawer/constants/empty.constant.ts
@@ -1,5 +1,5 @@
 export const NOT_FOUND_TEXT: Record<
-  'SEARCH' | 'STAR' | 'MYDRAWER' | 'PROVIDER',
+  'SEARCH' | 'STAR' | 'MYDRAWER' | 'PROVIDER' | 'CATEGORY',
   { boldText: string; subText: string }
 > = {
   SEARCH: {
@@ -15,6 +15,10 @@ export const NOT_FOUND_TEXT: Record<
     subText: '새로운 서비스를 등록해보세요.',
   },
   PROVIDER: {
+    boldText: '아직 해당 카테고리에 업로드한 서비스가 없습니다.',
+    subText: '',
+  },
+  CATEGORY: {
     boldText: '현재 해당 카테고리에 등록된 서비스가 없습니다.',
     subText: '다른 카테고리를 확인해보세요!',
   },

--- a/src/drawer/constants/empty.constant.ts
+++ b/src/drawer/constants/empty.constant.ts
@@ -1,5 +1,5 @@
 export const NOT_FOUND_TEXT: Record<
-  'SEARCH' | 'STAR' | 'MYDRAWER' | 'PROVIDER' | 'CATEGORY',
+  'SEARCH' | 'STAR' | 'MYDRAWER' | 'CATEGORY',
   { boldText: string; subText: string }
 > = {
   SEARCH: {
@@ -13,10 +13,6 @@ export const NOT_FOUND_TEXT: Record<
   MYDRAWER: {
     boldText: '내가 등록한 서비스가 없습니다.',
     subText: '새로운 서비스를 등록해보세요.',
-  },
-  PROVIDER: {
-    boldText: '아직 해당 카테고리에 업로드한 서비스가 없습니다.',
-    subText: '',
   },
   CATEGORY: {
     boldText: '현재 해당 카테고리에 등록된 서비스가 없습니다.',

--- a/src/drawer/constants/empty.constant.ts
+++ b/src/drawer/constants/empty.constant.ts
@@ -1,7 +1,6 @@
-export const NOT_FOUND_TEXT: Record<
-  'SEARCH' | 'STAR' | 'MYDRAWER' | 'CATEGORY',
-  { boldText: string; subText: string }
-> = {
+import { EmptyStateType } from '../types/emptyState.type';
+
+export const NOT_FOUND_TEXT: Record<EmptyStateType, { boldText: string; subText: string }> = {
   SEARCH: {
     boldText: '해당 검색어에 대한 검색결과가 없습니다.',
     subText: '더 간단한 단어로 검색하거나 직접 서비스를 등록해보세요.',

--- a/src/drawer/pages/NewRelease/NewRelease.tsx
+++ b/src/drawer/pages/NewRelease/NewRelease.tsx
@@ -84,7 +84,7 @@ export const NewRelease = () => {
                 );
               })}
           </StyledCardContainer>
-          {!newReleases.pages[0].length && <EmptyScreen type="PROVIDER" />}
+          {!newReleases.pages[0].length && <EmptyScreen type="CATEGORY" />}
         </div>
       </StyledRankingContainer>
     </StyledContainer>

--- a/src/drawer/pages/NewRelease/NewRelease.tsx
+++ b/src/drawer/pages/NewRelease/NewRelease.tsx
@@ -84,7 +84,7 @@ export const NewRelease = () => {
                 );
               })}
           </StyledCardContainer>
-          {!newReleases.pages[0].length && <EmptyScreen type="CATEGORY" />}
+          {newReleases.pages[0].length === 0 && <EmptyScreen type="CATEGORY" />}
         </div>
       </StyledRankingContainer>
     </StyledContainer>

--- a/src/drawer/pages/NewRelease/NewRelease.tsx
+++ b/src/drawer/pages/NewRelease/NewRelease.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { CategoryDropdownMenu } from '@/drawer/components/Category/CategoryDropdownMenu/CategoryDropdownMenu';
 import { RankingCategory } from '@/drawer/components/Category/RankingCategory';
 import { BigDrawerCard } from '@/drawer/components/DrawerCard/BigDrawerCard';
+import { EmptyScreen } from '@/drawer/components/EmptyScreen/EmptyScreen';
 import { SMALL_DESKTOP_MEDIA_QUERY } from '@/drawer/constants/mobileview.constant';
 import { useGetNewRelease } from '@/drawer/hooks/useGetNewRelease';
 import { CategoryState } from '@/drawer/recoil/CategoryState';
@@ -83,6 +84,7 @@ export const NewRelease = () => {
                 );
               })}
           </StyledCardContainer>
+          {!newReleases.pages[0].length && <EmptyScreen type="PROVIDER" />}
         </div>
       </StyledRankingContainer>
     </StyledContainer>

--- a/src/drawer/pages/Provider/Provider.tsx
+++ b/src/drawer/pages/Provider/Provider.tsx
@@ -43,7 +43,7 @@ export const Provider = () => {
           <StyledDescription>개발자의 서비스를 확인해보세요.</StyledDescription>
         </div>
         {isEmpty ? (
-          <EmptyScreen type={'PROVIDER'} />
+          <EmptyScreen type={'CATEGORY'} />
         ) : (
           <>
             <CardLayout data={data.pages.flatMap((page) => page.products)} type={'PROVIDER'} />

--- a/src/drawer/pages/StarRanking/StarRanking.tsx
+++ b/src/drawer/pages/StarRanking/StarRanking.tsx
@@ -85,7 +85,7 @@ export const StarRanking = () => {
                 );
               })}
           </StyledCardContainer>
-          {!rankings.pages[0].length && <EmptyScreen type="PROVIDER" />}
+          {!rankings.pages[0].length && <EmptyScreen type="CATEGORY" />}
         </div>
       </StyledRankingContainer>
     </StyledContainer>

--- a/src/drawer/pages/StarRanking/StarRanking.tsx
+++ b/src/drawer/pages/StarRanking/StarRanking.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { CategoryDropdownMenu } from '@/drawer/components/Category/CategoryDropdownMenu/CategoryDropdownMenu';
 import { RankingCategory } from '@/drawer/components/Category/RankingCategory';
 import { BigDrawerCard } from '@/drawer/components/DrawerCard/BigDrawerCard';
+import { EmptyScreen } from '@/drawer/components/EmptyScreen/EmptyScreen';
 import { SMALL_DESKTOP_MEDIA_QUERY } from '@/drawer/constants/mobileview.constant';
 import { useGetStarRank } from '@/drawer/hooks/useGetStarRank';
 import { CategoryState } from '@/drawer/recoil/CategoryState';
@@ -84,6 +85,7 @@ export const StarRanking = () => {
                 );
               })}
           </StyledCardContainer>
+          {!rankings.pages[0].length && <EmptyScreen type="PROVIDER" />}
         </div>
       </StyledRankingContainer>
     </StyledContainer>

--- a/src/drawer/pages/StarRanking/StarRanking.tsx
+++ b/src/drawer/pages/StarRanking/StarRanking.tsx
@@ -85,7 +85,7 @@ export const StarRanking = () => {
                 );
               })}
           </StyledCardContainer>
-          {!rankings.pages[0].length && <EmptyScreen type="CATEGORY" />}
+          {rankings.pages[0].length === 0 && <EmptyScreen type="CATEGORY" />}
         </div>
       </StyledRankingContainer>
     </StyledContainer>

--- a/src/drawer/types/emptyState.type.ts
+++ b/src/drawer/types/emptyState.type.ts
@@ -1,0 +1,1 @@
+export type EmptyStateType = 'SEARCH' | 'STAR' | 'MYDRAWER' | 'CATEGORY';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #278 

### 기존 코드에 영향을 미치지 않는 변경사항
StarRanking과 NewRelease에 카테고리별 서비스가 하나도 없을 시 나타내는 emptyscreen 관련 코드를 추가하였습니다.

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/c7b6cec0-d40c-464f-af75-ac52f150e81d">


## 2️⃣ 알아두시면 좋아요!
피그마에 해당 카테고리가 없을 때 나타나는 화면이 없어서 다음처럼 멘트를 수정했습니다!
```ts
    boldText: '현재 해당 카테고리에 등록된 서비스가 없습니다.',
    subText: '다른 카테고리를 확인해보세요!',
```
(PROVIDER가 알고보니 카테고리 없을 때 나타내는 emptyscreen이더라구요..? 뒤늦게 알았지만 이참에 멘트 한번 더 수정하는 것도 나쁘지 않을 것 같아 수정했습니당)

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
