### PR TITLE
fix: version 1.0.0 으로 푸터 텍스트 수정

### DIFF
--- a/src/drawer/components/Footer/Footer.tsx
+++ b/src/drawer/components/Footer/Footer.tsx
@@ -4,7 +4,7 @@ export const Footer = () => {
   return (
     <StyledFooter>
       <StyledFooterLogo>SOOMSIL DRAWERS</StyledFooterLogo>
-      <StyledFooterText>Version n.n.n</StyledFooterText>
+      <StyledFooterText>Version 1.0.0</StyledFooterText>
     </StyledFooter>
   );
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #265 

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/b8d9cf6d-dbbc-4beb-b013-28f2ee2e3318">

### 기존 코드에 영향을 미치지 않는 변경사항
```ts
      <StyledFooterText>Version 1.0.0</StyledFooterText>
```

드디어 푸터에 n.n.n을 없앴습니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
