### PR TITLE
fix: formatDateTime에서 시간이 제대로 변환되지 않는 문제

### DIFF
--- a/src/utils/formatDateTime.ts
+++ b/src/utils/formatDateTime.ts
@@ -2,10 +2,10 @@ export const formatDateTime = (basedTime: string): string => {
   const dateObject = new Date(basedTime);
   const realTimeDate = {
     year: dateObject.getFullYear(),
-    month: (dateObject.getMonth() + 1).toString().padStart(2, '0'),
-    day: dateObject.getDate().toString().padStart(2, '0'),
+    month: (dateObject.getMonth() + 1).toString(),
+    day: dateObject.getDate().toString(),
     hour: dateObject.getHours().toString().padStart(2, '0'),
     minute: dateObject.getMinutes().toString().padStart(2, '0'),
   };
-  return `${realTimeDate.year}.${realTimeDate.month}.${realTimeDate.day} ${realTimeDate.hour}:${realTimeDate.minute}`;
+  return `${realTimeDate.year}년 ${realTimeDate.month}월 ${realTimeDate.day}일 ${realTimeDate.hour}:${realTimeDate.minute}`;
 };

--- a/src/utils/formatDateTime.ts
+++ b/src/utils/formatDateTime.ts
@@ -3,9 +3,9 @@ export const formatDateTime = (basedTime: string): string => {
   const realTimeDate = {
     year: dateObject.getFullYear(),
     month: (dateObject.getMonth() + 1).toString().padStart(2, '0'),
-    day: (dateObject.getDate() + 1).toString().padStart(2, '0'),
-    hour: (dateObject.getHours() + 1).toString().padStart(2, '0'),
-    minute: (dateObject.getMinutes() + 1).toString().padStart(2, '0'),
+    day: dateObject.getDate().toString().padStart(2, '0'),
+    hour: dateObject.getHours().toString().padStart(2, '0'),
+    minute: dateObject.getMinutes().toString().padStart(2, '0'),
   };
   return `${realTimeDate.year}.${realTimeDate.month}.${realTimeDate.day} ${realTimeDate.hour}:${realTimeDate.minute}`;
 };

--- a/src/utils/formatDateTime.ts
+++ b/src/utils/formatDateTime.ts
@@ -1,11 +1,11 @@
 export const formatDateTime = (basedTime: string): string => {
   const dateObject = new Date(basedTime);
-  const realTimeDate = {
-    year: dateObject.getFullYear(),
-    month: (dateObject.getMonth() + 1).toString(),
-    day: dateObject.getDate().toString(),
-    hour: dateObject.getHours().toString().padStart(2, '0'),
-    minute: dateObject.getMinutes().toString().padStart(2, '0'),
-  };
-  return `${realTimeDate.year}년 ${realTimeDate.month}월 ${realTimeDate.day}일 ${realTimeDate.hour}:${realTimeDate.minute}`;
+
+  const year = dateObject.getFullYear();
+  const month = dateObject.getMonth() + 1;
+  const day = dateObject.getDate();
+  const hour = dateObject.getHours().toString().padStart(2, '0');
+  const minute = dateObject.getMinutes().toString().padStart(2, '0');
+
+  return `${year}년 ${month}월 ${day}일 ${hour}:${minute}`;
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #297

### 버그 픽스

`formatDateTime` 함수 내에 불필요한 `+1`을 삭제했습니다

히스토리 추적해보니까 [초반 커밋](https://github.com/yourssu/Soomsil-Web/pull/85/commits/882dbeb5103ed4e8109ecb043899905554a8ac34)에는 day/hour/minute에 `+1`이 없는데 [유틸로 분리](https://github.com/yourssu/Soomsil-Web/pull/85/commits/5b7490bfacd6543ea6205087a39ece851375b39f)하면서 생겼더라고요

잘못 붙어있는 게 맞는 거 같아 지웠습니다

| before | after |
|:---:|:---:|
|![image](https://github.com/user-attachments/assets/55d23a4a-9e2a-4e1e-b8e0-ca1275cff6e5)|![image](https://github.com/user-attachments/assets/b0a588b0-6a79-4d4b-bf6f-44e8ea86df5a)|


## 2️⃣ 알아두시면 좋아요!

앱과 날짜 형식이 다른 문제는 앱 형식으로 통일했습니다 ([관련 스레드](https://yourssu.slack.com/archives/C0661SMJ8DQ/p1725273062180819))

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
