### PR TITLE
fix: `100vw`에서 세로 스크롤 때문에 가로 스크롤이 생기는 문제

### DIFF
--- a/src/search/pages/Search/Search.style.ts
+++ b/src/search/pages/Search/Search.style.ts
@@ -5,7 +5,7 @@ import { StyledFlexContainer } from '@/components/FlexContainer/FlexContainer.st
 export const StyledSearchWrap = styled.div`
   position: absolute;
   top: 0;
-  width: 100vw;
+  width: 100%;
 
   display: flex;
   flex-direction: column;
@@ -19,7 +19,6 @@ export const StyledResultWrap = styled.div`
 `;
 
 export const StyledResultContentWrap = styled.div`
-  width: 100vw;
   padding: 1.5rem 2.5rem;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- #267 

### 버그 픽스

| before | after |
|:---:|:---:|
|<img width="960" alt="scroll" src="https://github.com/user-attachments/assets/8333ed90-4828-4ff1-ba9b-53e6e587d68d">|<img width="959" alt="no scroll" src="https://github.com/user-attachments/assets/af11d87c-f741-4677-af94-50f9673ed23f">|

## 2️⃣ 알아두시면 좋아요!

- 제가 작업했던 부분이 아니라 약간,, 걱정이 되는데 괜찮은지 꼭 ㅠㅠ!!! 실행해서 봐주세요

- Search에 적용된 100vw 2개 때문에 그럼

  - 검색 결과는 길어서 세로 스크롤이 생기는데
  - 이 세로 스크롤의 너비 때문에
  - `100vw`임에도 가로 스크롤이 생기는 것

~vw 알러지 생길 거 같아요~

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
