### PR TITLE
fix: 메일 인증 시간 10초 -> 8분으로 변경

### DIFF
--- a/src/home/components/SignupContents/EmailAuth/useEmailAuth.ts
+++ b/src/home/components/SignupContents/EmailAuth/useEmailAuth.ts
@@ -11,7 +11,7 @@ import { useSecondTimer } from '@/hooks/useSecondTimer.ts';
 
 export const useEmailAuth = ({ onConfirm, email }: EmailAuthProps) => {
   const [authed, setAuthed] = useState(true);
-  const { leftTime, isTimerEnd, resetTimer } = useSecondTimer(10);
+  const { leftTime, isTimerEnd, resetTimer } = useSecondTimer(8 * 60); // 8분
   const [error, setError] = useState<string>('');
   const [emailSending, setEmailSending] = useState(false);
 


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #307 
<img width="492" alt="image" src="https://github.com/user-attachments/assets/fbe7b3a7-d08a-477e-87f6-ef664aa4603d">


### 기존 코드에 영향을 미치는 변경사항
- #299 에서 10초로 변경되었던 학교 메일 인증 시간을 8분으로 변경하였습니다.

## 2️⃣ 알아두시면 좋아요!

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
