### PR TITLE
feat: 빌드 테스트용 워크플로우 추가

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,30 @@
+name: Main Branch Build test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-test:
+    name: Build Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,8 +1,6 @@
-name: Main Branch Build test
+name: Branch Build test
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

### 기존 코드에 영향을 미치지 않는 변경사항

- PR 열릴 때 빌드 테스트 진행하도록 워크플로우 추가

## 2️⃣ 알아두시면 좋아요!

### 왜 이 작업을 하게 되었는지

- feature ➡️ develop PR은 3명의 approval을 받아야 머지 가능
  develop ➡️ main PR은 위에서 리뷰 받았는데 또 기다리는 게 시간 낭비라고 생각했음 ([20241223 회의록](https://www.notion.so/yourssu/20241223-2da2d1299a584b24af27b0211a394ec1?pvs=4#12602c78f94e4806aaabf6f67c196e9d))

- 리뷰 안 거치면 빌드 실패하는데 모르고 머지할 수 있으니 방지턱으로 워크플로우 추가

### 추가한 ruleset에 대한 설명

- Soomsil-Web 레포에 `Pre-Commit Build Check` 라는 이름의 룰을 추가했습니다

  - 대상: 모든 브랜치
  - 조건: status check 통과 && force push 금지

    ![image](https://github.com/user-attachments/assets/2e46830c-d1ce-4a39-98aa-67fcdd5e5bbf)

- status check를 통과해야 push 할 수 있습니다

  - 빌드 실패하는 코드가 있다 = Build Test 실패 = status check 실패 = 커밋 못 함
  - 이때 에러 로그는 사진과 같습니다. 커밋 안 되면 이걸 의심해보세요..........

    ![commit failed](https://github.com/user-attachments/assets/b95cdbfe-b3d3-49f6-a3a7-67ab6119c70d)


## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
