### PR TITLE
fix: Update auto-assign-reviewer.yml

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [opened, reopened]
 
-permissions:
-  pull-requests: write
-
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
@@ -17,6 +14,6 @@ jobs:
       - name: Run action (auto-assign-reviewer/action.yml)
         uses: nijuy/auto-reviewer-assign@main
         with:
-          github_token: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           code_owners: ${{ vars.CODE_OWNERS }}
           reviewer_count: 3


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

### 기존 코드에 영향을 미치지 않는 변경사항

- fine-grained token 대신 [GITHUB_TOKEN](https://docs.github.com/ko/actions/security-for-github-actions/security-guides/automatic-token-authentication) 사용 ➡️ 3달마다 토큰 연장 안 해도 되게 하려고

- permission 키 삭제 ➡️ 리포지토리 설정에서 이미 권한 부여가 되어있길래

  > Settings - Actions - General - Workflow permissions - `read and write permissions` 으로 되어있음

## 2️⃣ 알아두시면 좋아요!

- 하게 된 배경은 [20250203 회의록](https://www.notion.so/yourssu/20250203-0d4665c88f3e462e8ce9b76929277bad?pvs=4#a055a9fc8ed14822976d0210639d8192) 봐주세용

- secrets에 등록해놨던 REVIEWER_GITHUB_TOKEN는 삭제했어요

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
